### PR TITLE
chore: initialize sola-raylib fork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-# raylib-rs Changelog
+# sola-raylib Changelog
+
+Originally the raylib-rs Changelog; sola-raylib is a fork of raylib-rs.
+Outdated and incomplete.
 
 ## 3.7.0 (WIP)
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,12 @@
 # License
 
+Copyright (c) 2026- Brett Chalupa (sola-raylib fork)
+Copyright (c) 2020-2025 raylib-rs contributors
 Copyright (c) 2018-2019 Paul Clement (@deltaphc)
+
+sola-raylib is a fork of raylib-rs (https://github.com/raylib-rs/raylib-rs),
+which is itself a fork of deltaphc/raylib-rs. Per clause 2 below, this is an
+altered version and is marked as such.
 
 This software is provided "as-is", without any express or implied warranty. In no event will the authors be held liable for any damages arising from the use of this software.
 

--- a/README.md
+++ b/README.md
@@ -7,35 +7,62 @@
 </td>
 <td>
 
-# raylib-rs
+# sola-raylib
 
-raylib-rs is a Rust binding for [raylib](http://www.raylib.com/) 5.5. It currently targets Rust toolchain version 1.78 or higher.
+sola-raylib is an actively maintained Rust bindings and wrapper for
+[raylib](http://www.raylib.com/) 5.5. It currently targets Rust toolchain
+version 1.78 or higher.
+
+**Versioning:** sola-raylib's major version tracks raylib's major version — 5.x
+binds raylib 5.5, 6.x will bind raylib 6.0, and so on. Minor and patch numbers
+are sola-raylib's own (raylib doesn't follow strict semver, so this project
+doesn't try to mirror it beyond the major).
+
+This project is a fork of
+[github.com/raylib-rs/raylib-rs](https://github.com/raylib-rs/raylib-rs) from
+commit
+[91bcb492c61dc067945d59357ca6def0d83fcb2c](https://github.com/raylib-rs/raylib-rs/commit/91bcb492c61dc067945d59357ca6def0d83fcb2c)
+(v5.5.1 release), which was a fork of
+[github.com/deltaphc/raylib-rs](https://github.com/deltaphc/raylib-rs).
 
 Please checkout the showcase directory to find usage examples!
 
-Though this binding tries to stay close to the simple C API, it makes some changes to be more idiomatic for Rust.
+Though this binding tries to stay close to the simple C API, it makes some
+changes to be more idiomatic for Rust.
 
 </td>
 </tr>
 </table>
 
-Most development happens over at: https://github.com/raylib-rs/raylib-rs
-
-
-- Resources are automatically cleaned up when they go out of scope (or when `std::mem::drop` is called). This is essentially RAII. This means that "Unload" functions are not exposed (and not necessary unless you obtain a `Weak` resource using make_weak()).
-- Most of the Raylib API is exposed through `RaylibHandle`, which is for enforcing that Raylib is only initialized once, and for making sure the window is closed properly. RaylibHandle has no size and goes away at compile time. Because of mutability rules, Raylib-rs is thread safe!
-- A `RaylibHandle` and `RaylibThread` are obtained through `raylib::init_window(...)` or through the newer `init()` function which will allow you to `build` up some window options before initialization (replaces `set_config_flags`). RaylibThread should not be sent to any other threads, or used in a any syncronization primitives (Mutex, Arc) etc.
-- Manually closing the window is unnecessary, because `CloseWindow` is automatically called when `RaylibHandle` goes out of scope.
-- `Model::set_material`, `Material::set_shader`, and `MaterialMap::set_texture` methods were added since one cannot set the fields directly. Also enforces correct ownership semantics.
-- `Font::from_data`, `Font::set_chars`, and `Font::set_texture` methods were added to create a `Font` from loaded `CharInfo` data.
-- `SubText` and `FormatText` are omitted, and are instead covered by Rust's string slicing and Rust's `format!` macro, respectively.
+- Resources are automatically cleaned up when they go out of scope (or when
+  `std::mem::drop` is called). This is essentially RAII. This means that
+  "Unload" functions are not exposed (and not necessary unless you obtain a
+  `Weak` resource using make_weak()).
+- Most of the Raylib API is exposed through `RaylibHandle`, which is for
+  enforcing that Raylib is only initialized once, and for making sure the window
+  is closed properly. RaylibHandle has no size and goes away at compile time.
+  Because of mutability rules, Raylib-rs is thread safe!
+- A `RaylibHandle` and `RaylibThread` are obtained through
+  `raylib::init_window(...)` or through the newer `init()` function which will
+  allow you to `build` up some window options before initialization (replaces
+  `set_config_flags`). RaylibThread should not be sent to any other threads, or
+  used in a any syncronization primitives (Mutex, Arc) etc.
+- Manually closing the window is unnecessary, because `CloseWindow` is
+  automatically called when `RaylibHandle` goes out of scope.
+- `Model::set_material`, `Material::set_shader`, and `MaterialMap::set_texture`
+  methods were added since one cannot set the fields directly. Also enforces
+  correct ownership semantics.
+- `Font::from_data`, `Font::set_chars`, and `Font::set_texture` methods were
+  added to create a `Font` from loaded `CharInfo` data.
+- `SubText` and `FormatText` are omitted, and are instead covered by Rust's
+  string slicing and Rust's `format!` macro, respectively.
 
 # Installation
 
 ## Supported Platforms
 
-| API    | Windows            | Linux              | macOS              | Web                | Android | 
-| ------ | ------------------ | ------------------ | ------------------ | --------------     | ------- |
+| API    | Windows            | Linux              | macOS              | Web                | Android |
+| ------ | ------------------ | ------------------ | ------------------ | ------------------ | ------- |
 | core   | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :x:     |
 | rgui   | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | ❔                 | :x:     |
 | physac | :construction:     | :construction:     | :construction:     | ❔                 | :x:     |
@@ -43,15 +70,36 @@ Most development happens over at: https://github.com/raylib-rs/raylib-rs
 
 ## Build Dependencies
 
-Requires glfw, cmake, and curl. Tips on making things work smoothly on all platforms is appreciated.
-Follow instructions for building raylib for your platform [here](https://github.com/raysan5/raylib/wiki)
+Requires glfw, cmake, and curl. Tips on making things work smoothly on all
+platforms is appreciated. Follow instructions for building raylib for your
+platform [here](https://github.com/raysan5/raylib/wiki)
 
 1. Add the dependency to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-raylib = { version = "5.5" }
+sola-raylib = "5.5"
 ```
+
+Then in your code, use it as `sola_raylib`:
+
+```rust
+use sola_raylib::prelude::*;
+```
+
+### Drop-in replacement for `raylib-rs`
+
+If you're migrating an existing `raylib-rs` project and don't want to touch
+every `use raylib::...` statement, use Cargo's package rename so the crate is
+still imported as `raylib` in your source code:
+
+```toml
+[dependencies]
+raylib = { package = "sola-raylib", version = "5.5" }
+```
+
+With that line, all your existing `use raylib::prelude::*` imports keep working
+— only `Cargo.toml` changes.
 
 2. Start coding!
 
@@ -73,54 +121,83 @@ fn main() {
 }
 ```
 
-### NixOS
+## Cross-compiling using `cross`
 
-To use raylib-rs on NixOS there's a provided nix-shell file `shell.nix` at the root of the repo that should get you up and running, which can be used like so:
+Cross compiling with sola-raylib can be made easier with cross. See the
+[upstream raylib-rs wiki](https://github.com/raylib-rs/raylib-rs/wiki/Cross%E2%80%90compiling-using-cross)
+for a writeup that should still largely apply.
 
-`nix-shell ./shell.nix`
+## Developing
 
-You'll also need to enable the Wayland feature on the raylib crate: 
+[just](https://just.systems/man/en/) is used for running commands while working
+on the project. See `./justfile` for available commands. `just ok` is a helpful
+command to run regularly and ensure is passing.
 
-`cargo add raylib -F wayland`
+### Tech Notes
 
-Contributions are welcome to improve or fix the shell.nix!
+- Structs holding resources have RAII/move semantics, including: `Image`,
+  `Texture2D`, `RenderTexture2D`, `Font`, `Mesh`, `Shader`, `Material`, and
+  `Model`.
+- `Wave`, `Sound`, `Music`, and `AudioStream` have lifetimes bound to
+  `AudioHandle`.
+- Functions dealing with string data take in `&str` and/or return an owned
+  `String`, for the sake of safety. The exception to this is the gui draw
+  functions which take &CStr to avoid per frame allocations. The `rstr!` macro
+  helps make this easy.
+- In C, `LoadFontData` returns a pointer to a heap-allocated array of `CharInfo`
+  structs. In this Rust binding, said array is copied into an owned
+  `Vec<CharInfo>`, the original data is freed, and the owned Vec is returned.
+- In C, `LoadDroppedFiles` returns a pointer to an array of strings owned by
+  raylib. Again, for safety and also ease of use, this binding copies said array
+  into a `Vec<String>` which is returned to the caller.
+- Linking is automatic, though I've only tested on Windows 10, Ubuntu, and
+  MacOS 15. Other platforms may have other considerations.
+- OpenGL 3.3, 2.1, and ES 2.0 may be forced via adding `["opengl_33"]`,
+  `["opengl_21"]` or `["opengl_es_20]` to the `features` array in your
+  Cargo.toml dependency definition.
 
-# Tech Notes
-
-- Structs holding resources have RAII/move semantics, including: `Image`, `Texture2D`, `RenderTexture2D`, `Font`, `Mesh`, `Shader`, `Material`, and `Model`.
-- `Wave`, `Sound`, `Music`, and `AudioStream` have lifetimes bound to `AudioHandle`. 
-- Functions dealing with string data take in `&str` and/or return an owned `String`, for the sake of safety. The exception to this is the gui draw functions which take &CStr to avoid per frame allocations. The `rstr!` macro helps make this easy.
-- In C, `LoadFontData` returns a pointer to a heap-allocated array of `CharInfo` structs. In this Rust binding, said array is copied into an owned `Vec<CharInfo>`, the original data is freed, and the owned Vec is returned.
-- In C, `LoadDroppedFiles` returns a pointer to an array of strings owned by raylib. Again, for safety and also ease of use, this binding copies said array into a `Vec<String>` which is returned to the caller.
-- I've tried to make linking automatic, though I've only tested on Windows 10, Ubuntu, and MacOS 15. Other platforms may have other considerations.
-- OpenGL 3.3, 2.1, and ES 2.0 may be forced via adding `["opengl_33"]`, `["opengl_21"]` or `["opengl_es_20]` to the `features` array in your Cargo.toml dependency definition.
-
-## Building from source
+### Building from source
 
 1. Clone repository: `git clone --recurse-submodules`
 2. `cargo build`
 
 ### If building for Wayland on Linux
 
-3. Install these packages:  
-`libglfw3-dev wayland-devel libxkbcommon-devel wayland-protocols wayland-protocols-devel libecm-dev`
-###### Note that this may not be a comprehensive list, please add details for your distribution or expand on these packages if you believe this to be incomplete.
-
+3. Install these packages:\
+   `libglfw3-dev wayland-devel libxkbcommon-devel wayland-protocols wayland-protocols-devel libecm-dev`
 4. Enable wayland by adding `features=["wayland"]` to your dependency definition
 
-## Cross-compiling using `cross`
+**Note that the packages may not be a comprehensive list, please add details for
+your distribution or expand on these packages if you believe this to be
+incomplete.**
 
-Cross compiling with raylib-rs can be made easier with cross. [See more on the wiki](https://github.com/raylib-rs/raylib-rs/wiki/Cross%E2%80%90compiling-using-cross)
+### NixOS
 
-# Extras
+To use raylib-rs on NixOS there's a provided nix-shell file `shell.nix` at the
+root of the repo that should get you up and running, which can be used like so:
 
-- In addition to the base library, there is also a convenient `ease` module which contains various interpolation/easing functions ported from raylib's `easings.h`, as well as a `Tween` struct to assist in using these functions.
-- Equivalent math and vector operations, ported from `raymath.h`, are `impl`ed on the various Vector and Matrix types. Operator overloading is used for more intuitive design.
+`nix-shell ./shell.nix`
 
-# Testing
+You'll also need to enable the Wayland feature on the raylib crate:
 
-The raylib-test crate tests the bindings by opening a window, and checking the results of various functions. It requires nightly to use.
+`cargo add raylib -F wayland`
 
-# Contribution & Support
+Contributions are welcome to improve or fix the shell.nix!
 
-All contributions are welcome. Chat about raylib on [discord](https://discord.gg/VkzNHUE)
+## Extras
+
+- In addition to the base library, there is also a convenient `ease` module
+  which contains various interpolation/easing functions ported from raylib's
+  `easings.h`, as well as a `Tween` struct to assist in using these functions.
+- Equivalent math and vector operations, ported from `raymath.h`, are `impl`ed
+  on the various Vector and Matrix types. Operator overloading is used for more
+  intuitive design.
+
+## Testing
+
+The sola-raylib-test crate tests the bindings by opening a window, and checking
+the results of various functions. It requires nightly to use.
+
+## Contribution & Support
+
+All contributions are welcome, see ./CONTRIBUTE.md for more details.

--- a/justfile
+++ b/justfile
@@ -1,0 +1,37 @@
+# sola-raylib dev tasks
+# Run `just` to see all recipes, `just <name>` to run one.
+
+default:
+    @just --list
+
+# Run all checks that should be green before committing/pushing.
+ok: build clippy doctest
+    @echo "All checks passed."
+
+# Build every crate in the workspace.
+build:
+    cargo build --workspace
+
+# Lint every crate and target. Warnings are allowed for now (lots of pre-existing upstream noise).
+clippy:
+    cargo clippy --workspace --all-targets
+
+# Run doc tests (real tests require a display and are run manually).
+doctest:
+    cargo test --doc --workspace
+
+# Format all code in place.
+fmt:
+    cargo fmt --all
+
+# TODO: re-enable once the workspace is cleanly formatted end-to-end.
+# fmt-check:
+#     cargo fmt --all -- --check
+
+# Build the sample binaries crate.
+samples:
+    cd samples && cargo build
+
+# Run a specific sample by name, e.g. `just sample drop`.
+sample name:
+    cd samples && cargo run --bin {{name}}

--- a/raylib-sys/Cargo.toml
+++ b/raylib-sys/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "raylib-sys"
+name = "sola-raylib-sys"
 version = "5.5.1"
-authors = ["raylib-rs team <https://github.com/raylib-rs/raylib-rs>"]
+authors = ["Brett Chalupa <brett@brettchalupa.com>", "raylib-rs team <https://github.com/raylib-rs/raylib-rs>"]
 license = "Zlib"
-description = "Raw FFI bindings for Raylib"
-documentation = "https://docs.rs/raylib-sys"
-repository = "https://github.com/raylib-rs/raylib-rs"
+description = "Raw FFI bindings for raylib. sola-raylib-sys N.x tracks raylib N.x (e.g. 5.x → raylib 5.5; 6.x → raylib 6.0)."
+documentation = "https://docs.rs/sola-raylib-sys"
+repository = "https://github.com/brettchalupa/sola-raylib-rs"
 keywords = ["bindings", "raylib", "gamedev", "ffi"]
 categories = ["external-ffi-bindings"]
 edition = "2018"

--- a/raylib-test/Cargo.toml
+++ b/raylib-test/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
-name = "raylib-test"
+name = "sola-raylib-test"
 version = "5.5.1"
-authors = ["raylib-rs team <https://github.com/raylib-rs/raylib-rs>"]
+authors = ["Brett Chalupa <brett@brettchalupa.com>", "raylib-rs team <https://github.com/raylib-rs/raylib-rs>"]
 edition = "2018"
 license = "Zlib"
 readme = "../README.md"
-repository = "https://github.com/raylib-rs/raylib-rs"
+repository = "https://github.com/brettchalupa/sola-raylib"
 
 [dependencies]
-raylib = { version = "5.5.1", path = "../raylib" }
-raylib_sys = { version = "5.5.1", path = "../raylib-sys" }
+raylib = { package = "sola-raylib", version = "5.5.1", path = "../raylib" }
+raylib-sys = { package = "sola-raylib-sys", version = "5.5.1", path = "../raylib-sys" }
 lazy_static = "1.2.0"
 colored = "2.1.0"
 

--- a/raylib/Cargo.toml
+++ b/raylib/Cargo.toml
@@ -1,19 +1,19 @@
 [package]
-name = "raylib"
+name = "sola-raylib"
 version = "5.5.1"
-authors = ["raylib-rs team <https://github.com/raylib-rs/raylib-rs>"]
+authors = ["Brett Chalupa <brett@brettchalupa.com>", "raylib-rs team <https://github.com/raylib-rs/raylib-rs>"]
 license = "Zlib"
 readme = "../README.md"
-description = "Safe Rust bindings for Raylib."
-documentation = "https://docs.rs/raylib"
-repository = "https://github.com/raylib-rs/raylib-rs"
+description = "Safe Rust bindings for raylib. sola-raylib N.x tracks raylib N.x (e.g. 5.x → raylib 5.5; 6.x → raylib 6.0)."
+documentation = "https://docs.rs/sola-raylib"
+repository = "https://github.com/brettchalupa/sola-raylib"
 keywords = ["bindings", "raylib", "gamedev"]
 categories = ["api-bindings", "game-engines", "graphics"]
 edition = "2018"
 autoexamples = false
 
 [dependencies]
-raylib-sys = { version = "5.5.1", path = "../raylib-sys" }
+raylib-sys = { package = "sola-raylib-sys", version = "5.5.1", path = "../raylib-sys" }
 cfg-if = "1.0.0"
 serde = { version = "1.0.125", features = ["derive"], optional = true }
 serde_json = { version = "1.0.64", optional = true }

--- a/raylib/src/core/collision.rs
+++ b/raylib/src/core/collision.rs
@@ -20,7 +20,7 @@ impl Rectangle {
 
     /// Gets the overlap between two colliding rectangles.
     /// ```rust
-    /// use raylib::prelude::*;
+    /// use sola_raylib::prelude::*;
     /// fn main() {
     ///    let r1 = Rectangle::new(0.0, 0.0, 10.0, 10.0);
     ///    let r2 = Rectangle::new(20.0, 20.0, 10.0, 10.0);

--- a/raylib/src/core/color.rs
+++ b/raylib/src/core/color.rs
@@ -80,7 +80,7 @@ impl Color {
     /// * `color_hex_str` - A string slice, 6 characters long
     /// # Example
     /// ```
-    ///    use raylib::prelude::*;
+    ///    use sola_raylib::prelude::*;
     ///     let color_white = Color::from_hex("FFFFFF").unwrap();
     ///     let color_black = Color::from_hex("000000").unwrap();
     ///     
@@ -132,7 +132,7 @@ impl Color {
 
     /// Returns color from normalized values [0..1]
     /// ```rust
-    /// use raylib::prelude::*;
+    /// use sola_raylib::prelude::*;
     /// fn main() {    
     ///     assert_eq!(Color::color_from_normalized(Vector4::new(1.0, 1.0, 1.0, 1.0)), Color::new(255, 255, 255, 255));
     /// }

--- a/raylib/src/core/data.rs
+++ b/raylib/src/core/data.rs
@@ -11,7 +11,7 @@ use crate::{
 
 /// Compress data (DEFLATE algorythm)
 /// ```rust
-/// use raylib::prelude::*;
+/// use sola_raylib::prelude::*;
 /// let data = compress_data(b"11111").unwrap();
 /// let expected: &[u8] = &[1, 5, 0, 250, 255, 49, 49, 49, 49, 49];
 /// assert_eq!(data, expected);
@@ -31,7 +31,7 @@ pub fn compress_data(data: &[u8]) -> Result<&'static [u8], Error> {
 
 /// Decompress data (DEFLATE algorythm)
 /// ```rust
-/// use raylib::prelude::*;
+/// use sola_raylib::prelude::*;
 /// let input: &[u8] = &[1, 5, 0, 250, 255, 49, 49, 49, 49, 49];
 /// let expected: &[u8] = b"11111";
 /// let data = decompress_data(input).unwrap();

--- a/raylib/src/core/misc.rs
+++ b/raylib/src/core/misc.rs
@@ -58,7 +58,7 @@ impl<'a> Iterator for RandSeqIterator<'a> {
 
 /// Open URL with default system browser (if available)
 /// ```ignore
-/// use raylib::*;
+/// use sola_raylib::*;
 /// fn main() {
 ///     open_url("https://google.com");
 /// }
@@ -92,7 +92,7 @@ impl RaylibHandle {
 
     /// Returns a random value between min and max (both included)
     /// ```ignore
-    /// use raylib::*;
+    /// use sola_raylib::*;
     /// fn main() {
     ///     let (mut rl, thread) = ...;
     ///     let r = rl.get_random_value(0, 10);

--- a/raylib/src/core/window.rs
+++ b/raylib/src/core/window.rs
@@ -341,7 +341,7 @@ pub fn get_monitor_position(monitor: i32) -> Vector2 {
 /// fails if monitor name is not a utf8 string
 /// ```rust
 /// use std::ffi::IntoStringError;
-/// use raylib::prelude::*;
+/// use sola_raylib::prelude::*;
 /// fn main() -> Result<(), IntoStringError> {
 ///     let count = get_monitor_count();
 ///     for i in (0..count) {
@@ -366,7 +366,7 @@ pub fn get_monitor_info(monitor: i32) -> Result<MonitorInfo, IntoStringError> {
 
 /// Returns camera transform matrix (view matrix)
 /// ```rust
-/// use raylib::prelude::*;
+/// use sola_raylib::prelude::*;
 /// fn main() {
 ///     let c = Camera::perspective(
 ///            Vector3::zero(),
@@ -384,7 +384,7 @@ pub fn get_camera_matrix(camera: impl Into<ffi::Camera>) -> Matrix {
 
 /// Returns camera 2D transform matrix (view matrix)
 /// ```rust
-/// use raylib::prelude::*;
+/// use sola_raylib::prelude::*;
 /// fn main() {
 ///     let c = Camera2D::default();
 ///     let m = get_camera_matrix2D(&c);

--- a/raylib/src/lib.rs
+++ b/raylib/src/lib.rs
@@ -22,7 +22,7 @@ Permission is granted to anyone to use this software for any purpose, including 
 //!
 //! For more control over the game window, the [`init`] function will return a [`RaylibBuilder`] which allows for tweaking various settings such as VSync, anti-aliasing, fullscreen, and so on. Calling [`RaylibBuilder::build`] will then provide a [`RaylibHandle`].
 //!
-//! Some useful constants can be found in the [`consts`] module, which is also re-exported in the [`prelude`] module. In most cases you will probably want to `use raylib::prelude::*;` to make your experience more smooth.
+//! Some useful constants can be found in the [`consts`] module, which is also re-exported in the [`prelude`] module. In most cases you will probably want to `use sola_raylib::prelude::*;` to make your experience more smooth.
 //!
 //! [`init_window`]: fn.init_window.html
 //! [`init`]: fn.init.html
@@ -38,10 +38,10 @@ Permission is granted to anyone to use this software for any purpose, including 
 //! The classic "Hello, world":
 //!
 //! ```no_run
-//! use raylib::prelude::*;
+//! use sola_raylib::prelude::*;
 //!
 //! fn main() {
-//!     let (mut rl, thread) = raylib::init()
+//!     let (mut rl, thread) = sola_raylib::init()
 //!         .size(640, 480)
 //!         .title("Hello, World")
 //!         .build();

--- a/raylib/src/prelude.rs
+++ b/raylib/src/prelude.rs
@@ -21,7 +21,7 @@ Permission is granted to anyone to use this software for any purpose, including 
 //! # Example
 //!
 //! ```
-//! use raylib::prelude::*;
+//! use sola_raylib::prelude::*;
 //! ```
 
 pub use crate::callbacks::*;

--- a/samples/Cargo.toml
+++ b/samples/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
-name = "raylib-examples"
+name = "sola-raylib-examples"
 version = "5.5.1"
-authors = ["raylib-rs team <https://github.com/raylib-rs/raylib-rs>"]
+authors = ["Brett Chalupa <brett@brettchalupa.com>", "raylib-rs team <https://github.com/raylib-rs/raylib-rs>"]
 edition = "2021"
 license = "Zlib"
 readme = "../README.md"
-repository = "https://github.com/raylib-rs/raylib-rs"
+repository = "https://github.com/brettchalupa/sola-raylib"
 
 
 [dependencies]
-raylib = { path = "../raylib", version = "5.5.1" }
+raylib = { package = "sola-raylib", path = "../raylib", version = "5.5.1" }
 structopt = "0.2"
 specs-derive = "0.4.1"
 rand = "0.8"
@@ -27,10 +27,6 @@ ringbuf = ["dep:ringbuf"]
 [dependencies.specs]
 version = "0.16.1"
 default-features = false
-
-[[bin]]
-name = "specs"
-path = "./specs.rs"
 
 [[bin]]
 name = "rgui"

--- a/showcase/Cargo.toml
+++ b/showcase/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
-name = "raylib-showcase"
+name = "sola-raylib-showcase"
 version = "5.5.1"
-authors = ["raylib-rs team <https://github.com/raylib-rs/raylib-rs>"]
+authors = ["Brett Chalupa <brett@brettchalupa.com>", "raylib-rs team <https://github.com/raylib-rs/raylib-rs>"]
 edition = "2018"
 license = "Zlib"
 readme = "../README.md"
-repository = "https://github.com/raylib-rs/raylib-rs"
+repository = "https://github.com/brettchalupa/sola-raylib"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-raylib = { version = "5.5.1", path = "../raylib" }
+raylib = { package = "sola-raylib", version = "5.5.1", path = "../raylib" }


### PR DESCRIPTION
This renames crates, update copyright, revises `use` statements, and
tries to get the project into a working state from raylib-rs 5.5.1 for
making revisions and additions and supporting new Raylib versions.
