### PR TITLE
chore: fix clippy lints & check fmt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Clippy
         run: cargo clippy --workspace --all-targets
 
+      - name: Fmt
+        run: cargo fmt --all -- --check
+
       - name: Tests
         run: cargo test --workspace
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,12 @@
 [workspace]
 members = ["raylib", "raylib-sys"]
 exclude = ["raylib-test", "samples"]
+
+[workspace.lints.rust]
+# Workspace lints apply only to our own crates, never to dependencies.
+warnings = "deny"
+
+[workspace.lints.clippy]
+# The default clippy group (correctness, suspicious, style, complexity, perf).
+# Priority lets more-specific lints below (or per-crate/per-item) override.
+all = { level = "deny", priority = -1 }

--- a/README.md
+++ b/README.md
@@ -1,12 +1,3 @@
-<table border="0">
-<tr>
-<td>
-
-![logo](logo/raylib-rust_256x256.png)
-
-</td>
-<td>
-
 # sola-raylib
 
 sola-raylib is an actively maintained Rust bindings and wrapper for
@@ -29,10 +20,6 @@ Please checkout the showcase directory to find usage examples!
 
 Though this binding tries to stay close to the simple C API, it makes some
 changes to be more idiomatic for Rust.
-
-</td>
-</tr>
-</table>
 
 - Resources are automatically cleaned up when they go out of scope (or when
   `std::mem::drop` is called). This is essentially RAII. This means that
@@ -61,12 +48,16 @@ changes to be more idiomatic for Rust.
 
 ## Supported Platforms
 
-| API    | Windows            | Linux              | macOS              | Web                | Android |
-| ------ | ------------------ | ------------------ | ------------------ | ------------------ | ------- |
-| core   | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :x:     |
-| rgui   | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | ❔                 | :x:     |
-| physac | :construction:     | :construction:     | :construction:     | ❔                 | :x:     |
-| rlgl   | :heavy_check_mark: | :x:                | :x:                | ❔                 | :x:     |
+sola-raylib is focused on supporting Windows, Linux, macOS, and Web targets.
+
+The table below shows which core APIs are supported for which platforms:
+
+| API    | Windows            | Linux              | macOS              | Web                |
+| ------ | ------------------ | ------------------ | ------------------ | ------------------ |
+| core   | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
+| rgui   | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | ❔                 |
+| physac | :construction:     | :construction:     | :construction:     | ❔                 |
+| rlgl   | :heavy_check_mark: | :x:                | :x:                | ❔                 |
 
 ## Build Dependencies
 

--- a/justfile
+++ b/justfile
@@ -5,7 +5,7 @@ default:
     @just --list
 
 # Run all checks that should be green before committing/pushing.
-ok: build clippy test samples
+ok: fmt-check build clippy test samples
     @echo "All checks passed."
 
 # Build every crate in the workspace.
@@ -25,9 +25,8 @@ test:
 fmt:
     cargo fmt --all
 
-# TODO: re-enable once the workspace is cleanly formatted end-to-end.
-# fmt-check:
-#     cargo fmt --all -- --check
+fmt-check:
+    cargo fmt --all -- --check
 
 # Build the sample binaries crate.
 samples:
@@ -35,4 +34,4 @@ samples:
 
 # Run a specific sample by name, e.g. `just sample drop`.
 sample name:
-    cd samples && cargo run --bin {{name}}
+    cd samples && cargo run --bin {{ name }}

--- a/raylib-sys/Cargo.toml
+++ b/raylib-sys/Cargo.toml
@@ -49,3 +49,6 @@ custom_frame_control = []
 
 # ImGui support
 imgui = ["dep:imgui", "dep:imgui-sys"]
+
+[lints]
+workspace = true

--- a/raylib-sys/build.rs
+++ b/raylib-sys/build.rs
@@ -62,7 +62,7 @@ fn build_with_cmake(src_path: &str) {
 
     let mut conf = cmake::Config::new(src_path);
     let mut builder;
-    let mut profile = "";
+    let profile;
     #[cfg(debug_assertions)]
     {
         builder = conf.profile("Debug");
@@ -552,6 +552,7 @@ fn uname() -> String {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[allow(clippy::upper_case_acronyms)]
 enum Platform {
     Web,
     Desktop,
@@ -560,6 +561,7 @@ enum Platform {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[allow(clippy::upper_case_acronyms)]
 enum PlatformOS {
     Windows,
     Linux,

--- a/raylib-sys/src/lib.rs
+++ b/raylib-sys/src/lib.rs
@@ -12,6 +12,9 @@ include!(env!("RAYLIB_BINDGEN_LOCATION"));
 #[cfg(target_os = "macos")]
 pub const MAX_MATERIAL_MAPS: u32 = 12;
 
+// TraceLogLevel is bindgen-generated so we can't use `#[default]` on its
+// variants; the manual Default impl is the only way to select LOG_INFO here.
+#[allow(clippy::derivable_impls)]
 impl Default for TraceLogLevel {
     fn default() -> Self {
         TraceLogLevel::LOG_INFO

--- a/raylib/Cargo.toml
+++ b/raylib/Cargo.toml
@@ -48,3 +48,6 @@ imgui = ["raylib-sys/imgui", "dep:imgui", "dep:imgui-sys"]
 nobuild = ["raylib-sys/nobuild"]
 bindgen = ["raylib-sys/bindgen"]
 default = ["bindgen"]
+
+[lints]
+workspace = true

--- a/raylib/src/core/audio.rs
+++ b/raylib/src/core/audio.rs
@@ -161,7 +161,7 @@ impl RaylibAudio {
     pub fn new_music_from_memory<'aud>(
         &'aud self,
         filetype: &str,
-        bytes: &Vec<u8>,
+        bytes: &[u8],
     ) -> Result<Music<'aud>, Error> {
         let c_filetype = CString::new(filetype).unwrap();
         let w = unsafe {
@@ -192,7 +192,7 @@ impl RaylibAudio {
     }
 }
 
-impl<'aud> Drop for RaylibAudio {
+impl Drop for RaylibAudio {
     fn drop(&mut self) {
         unsafe { ffi::CloseAudioDevice() }
     }
@@ -211,6 +211,14 @@ impl<'aud> Wave<'aud> {
     pub fn channels(&self) -> u32 {
         self.0.channels
     }
+    /// Extract the raw FFI [`ffi::Wave`] value, bypassing the automatic `Drop` that would
+    /// normally free it.
+    ///
+    /// # Safety
+    /// After calling this function, the caller takes full responsibility for the underlying
+    /// raylib resource. The returned wave must eventually be freed via `ffi::UnloadWave` (or
+    /// reattached to a safe wrapper) to avoid leaking memory, and it must not be used after the
+    /// owning [`RaylibAudio`] has been dropped (which calls `CloseAudioDevice`).
     pub unsafe fn inner(self) -> ffi::Wave {
         let inner = self.0;
         std::mem::forget(self);
@@ -229,16 +237,9 @@ impl<'aud> Wave<'aud> {
         unsafe { ffi::ExportWave(self.0, c_filename.as_ptr()) }
     }
 
-    /// Export wave sample data to code (.h)
-    /*#[inline]
-    pub fn export_wave_as_code(&self, filename: &str) -> bool {
-        let c_filename = CString::new(filename).unwrap();
-        unsafe { ffi::ExportWaveAsCode(self.0, c_filename.as_ptr()) }
-    }*/
-
     /// Copies a wave to a new wave.
     #[inline]
-    pub(crate) fn copy(&self) -> Wave {
+    pub(crate) fn copy(&self) -> Wave<'_> {
         unsafe { Wave(ffi::WaveCopy(self.0), self.1) }
     }
 
@@ -286,6 +287,14 @@ impl<'aud> Sound<'aud> {
     pub fn frame_count(&self) -> u32 {
         self.0.frameCount
     }
+    /// Extract the raw FFI [`ffi::Sound`] value, bypassing the automatic `Drop` that would
+    /// normally free it.
+    ///
+    /// # Safety
+    /// After calling this function, the caller takes full responsibility for the underlying
+    /// raylib resource. The returned sound must eventually be freed via `ffi::UnloadSound` (or
+    /// reattached to a safe wrapper) to avoid leaking memory, and it must not be used after the
+    /// owning [`RaylibAudio`] has been dropped (which calls `CloseAudioDevice`).
     pub unsafe fn inner(self) -> ffi::Sound {
         let inner = self.0;
         std::mem::forget(self);
@@ -361,6 +370,15 @@ impl<'aud, 'bind> SoundAlias<'aud, 'bind> {
     pub fn frame_count(&self) -> u32 {
         self.0.frameCount
     }
+    /// Extract the raw FFI [`ffi::Sound`] value, bypassing the automatic `Drop` that would
+    /// normally free it.
+    ///
+    /// # Safety
+    /// After calling this function, the caller takes full responsibility for the underlying
+    /// raylib resource. The returned sound alias must eventually be freed via
+    /// `ffi::UnloadSoundAlias` (or reattached to a safe wrapper) to avoid leaking memory, and it
+    /// must not be used after its parent [`Sound`] or the owning [`RaylibAudio`] has been
+    /// dropped.
     pub unsafe fn inner(self) -> ffi::Sound {
         let inner = self.0;
         std::mem::forget(self);
@@ -512,6 +530,15 @@ impl<'aud> AudioStream<'aud> {
         self.0.channels
     }
 
+    /// Extract the raw FFI [`ffi::AudioStream`] value, bypassing the automatic `Drop` that
+    /// would normally free it.
+    ///
+    /// # Safety
+    /// After calling this function, the caller takes full responsibility for the underlying
+    /// raylib resource. The returned stream must eventually be freed via
+    /// `ffi::UnloadAudioStream` (or reattached to a safe wrapper) to avoid leaking memory, and
+    /// it must not be used after the owning [`RaylibAudio`] has been dropped (which calls
+    /// `CloseAudioDevice`).
     pub unsafe fn inner(self) -> ffi::AudioStream {
         let inner = self.0;
         std::mem::forget(self);
@@ -525,7 +552,7 @@ impl<'aud> AudioStream<'aud> {
             ffi::UpdateAudioStream(
                 self.0,
                 data.as_ptr() as *const std::os::raw::c_void,
-                (data.len() * std::mem::size_of::<T>()) as i32,
+                std::mem::size_of_val(data) as i32,
             );
         }
     }

--- a/raylib/src/core/callbacks.rs
+++ b/raylib/src/core/callbacks.rs
@@ -65,6 +65,13 @@ fn audio_stream_callback() -> Option<RustAudioStreamCallback> {
     unsafe { transmute(AUDIO_STREAM_CALLBACK.load(Ordering::Relaxed)) }
 }
 
+/// FFI trampoline invoked by raylib for trace log messages. It looks up the user-registered
+/// Rust callback and forwards the message.
+///
+/// # Safety
+/// This function is intended to be called only by raylib's C code. `text` must either be null
+/// or a pointer to a valid, NUL-terminated C string that lives for the duration of the call.
+/// The user-registered Rust callback must not panic or call raylib logging APIs reentrantly.
 #[no_mangle]
 pub unsafe extern "C" fn custom_trace_log_callback(level: TraceLogLevel, text: *const c_char) {
     if let Some(trace_log) = trace_log_callback() {
@@ -116,7 +123,7 @@ extern "C" fn custom_save_file_text_callback(a: *const c_char, b: *mut c_char) -
     let save_file_text = save_file_text_callback().unwrap();
     let a = unsafe { CStr::from_ptr(a) };
     let b = unsafe { CStr::from_ptr(b) };
-    return save_file_text(a.to_str().unwrap(), b.to_str().unwrap());
+    save_file_text(a.to_str().unwrap(), b.to_str().unwrap())
 }
 extern "C" fn custom_load_file_text_callback(a: *const c_char) -> *mut c_char {
     let load_file_text = load_file_text_callback().unwrap();
@@ -173,7 +180,7 @@ pub fn set_save_file_data_callback<'a>(cb: fn(&str, &[u8]) -> bool) -> Result<()
 /// Set custom file binary data loader
 ///
 /// Whatever you return from your callback will be intentionally leaked as Raylib is relied on to free it.
-pub fn set_load_file_data_callback<'b>(cb: fn(&str) -> Vec<u8>) -> Result<(), SetLogError<'b>> {
+pub fn set_load_file_data_callback<'a>(cb: fn(&str) -> Vec<u8>) -> Result<(), SetLogError<'a>> {
     safe_callback_set_func!(
         cb,
         LOAD_FILE_DATA_CALLBACK,
@@ -213,7 +220,7 @@ pub fn set_load_file_text_callback<'a>(cb: fn(&str) -> String) -> Result<(), Set
 /// should not be moved again! -> use Pin<..>)
 pub struct AudioStreamProcessorCallback<'a, F>
 where
-    F: FnMut(&mut [f32], u32) -> (),
+    F: FnMut(&mut [f32], u32),
 {
     rust_callback: &'a mut F,
     nb_channels: u32,
@@ -222,7 +229,7 @@ where
 
 impl<'a, F> AudioStreamProcessorCallback<'a, F>
 where
-    F: FnMut(&mut [f32], u32) -> (),
+    F: FnMut(&mut [f32], u32),
 {
     fn new(closure: &'a mut F, nb_channels_from_music: u32) -> Self {
         Self {
@@ -233,7 +240,7 @@ where
     }
 
     fn get_as_user_data(&mut self) -> *mut ::std::os::raw::c_void {
-        return self as *mut Self as *mut ::std::os::raw::c_void;
+        self as *mut Self as *mut ::std::os::raw::c_void
     }
 
     fn get_c_callback(
@@ -242,7 +249,7 @@ where
         *mut ::std::os::raw::c_void,
         *mut ::std::os::raw::c_void,
         ::std::os::raw::c_uint,
-    ) -> () {
+    ) {
         Self::c_callback
     }
 
@@ -250,24 +257,22 @@ where
         user_data: *mut ::std::os::raw::c_void,
         data_ptr: *mut ::std::os::raw::c_void,
         frame_count: ::std::os::raw::c_uint,
-    ) -> () {
+    ) {
         unsafe {
             let stream_processor_callback: &mut Self = user_data.cast::<Self>().as_mut().unwrap();
             let f32_ptr = data_ptr as *mut f32;
-            let data = unsafe {
-                std::slice::from_raw_parts_mut(
-                    f32_ptr,
-                    frame_count as usize * stream_processor_callback.nb_channels as usize,
-                )
-            };
+            let data = std::slice::from_raw_parts_mut(
+                f32_ptr,
+                frame_count as usize * stream_processor_callback.nb_channels as usize,
+            );
             (stream_processor_callback.rust_callback)(data, stream_processor_callback.nb_channels);
         }
     }
 }
 
-impl<'a, F> Drop for AudioStreamProcessorCallback<'a, F>
+impl<F> Drop for AudioStreamProcessorCallback<'_, F>
 where
-    F: FnMut(&mut [f32], u32) -> (),
+    F: FnMut(&mut [f32], u32),
 {
     fn drop(&mut self) {
         if let Some(index) = self.callback_index {
@@ -283,7 +288,7 @@ pub fn attach_audio_stream_processor_to_music<'a, F>(
     processor: &'a mut F,
 ) -> Pin<Box<AudioStreamProcessorCallback<'a, F>>>
 where
-    F: FnMut(&mut [f32], u32) -> () + Send + 'static, // static because the function is executed in another thread
+    F: FnMut(&mut [f32], u32) + Send + 'static, // static because the function is executed in another thread
 {
     let mut stream_processor_callback =
         Box::new(AudioStreamProcessorCallback::<'a, F>::new(processor, 2));
@@ -315,7 +320,7 @@ impl RaylibHandle {
     pub fn set_trace_log_callback(
         &mut self,
         cb: fn(TraceLogLevel, &str),
-    ) -> Result<(), SetLogError> {
+    ) -> Result<(), SetLogError<'_>> {
         set_trace_log_callback(cb)
     }
     /// Set custom file binary data saver
@@ -323,17 +328,17 @@ impl RaylibHandle {
     pub fn set_save_file_data_callback(
         &mut self,
         cb: fn(&str, &[u8]) -> bool,
-    ) -> Result<(), SetLogError> {
+    ) -> Result<(), SetLogError<'_>> {
         set_save_file_data_callback(cb)
     }
     /// Set custom file binary data loader
     ///
     /// Whatever you return from your callback will be intentionally leaked as Raylib is relied on to free it.
     #[deprecated = "Decoupled from RaylibHandle. Use [set_load_file_data_callback](core::callbacks::set_load_file_data_callback) instead."]
-    pub fn set_load_file_data_callback<'b>(
+    pub fn set_load_file_data_callback(
         &mut self,
         cb: fn(&str) -> Vec<u8>,
-    ) -> Result<(), SetLogError> {
+    ) -> Result<(), SetLogError<'_>> {
         set_load_file_data_callback(cb)
     }
     /// Set custom file text data saver
@@ -341,7 +346,7 @@ impl RaylibHandle {
     pub fn set_save_file_text_callback(
         &mut self,
         cb: fn(&str, &str) -> bool,
-    ) -> Result<(), SetLogError> {
+    ) -> Result<(), SetLogError<'_>> {
         set_save_file_text_callback(cb)
     }
     /// Set custom file text data loader
@@ -351,7 +356,7 @@ impl RaylibHandle {
     pub fn set_load_file_text_callback(
         &mut self,
         cb: fn(&str) -> String,
-    ) -> Result<(), SetLogError> {
+    ) -> Result<(), SetLogError<'_>> {
         set_load_file_text_callback(cb)
     }
 
@@ -361,7 +366,7 @@ impl RaylibHandle {
         &mut self,
         stream: AudioStream,
         cb: fn(&[u8]),
-    ) -> Result<(), SetLogError> {
+    ) -> Result<(), SetLogError<'_>> {
         if AUDIO_STREAM_CALLBACK.load(Ordering::Acquire) == 0 {
             AUDIO_STREAM_CALLBACK.store(cb as _, Ordering::Release);
             unsafe { ffi::SetAudioStreamCallback(stream.0, Some(custom_audio_stream_callback)) }

--- a/raylib/src/core/callbacks/stream_processor_with_user_data_wrapper.rs
+++ b/raylib/src/core/callbacks/stream_processor_with_user_data_wrapper.rs
@@ -32,7 +32,7 @@ impl AudioCallbackWithUserData {
         raw_callback: RawAudioCallbackWithUserData,
     ) -> Self {
         AudioCallbackWithUserData {
-            user_data: user_data,
+            user_data,
             callback: Some(raw_callback),
         }
     }
@@ -72,7 +72,7 @@ macro_rules! generate_functions {
               $(
                   {
                       let mut guard = [< CLOSURE_ $n >].lock().unwrap();
-                      if (*guard).callback == None {
+                      if (*guard).callback.is_none() {
                         *guard = audio_callback;
                         return $n;
                       }
@@ -86,7 +86,7 @@ macro_rules! generate_functions {
               $(
                   if index == $n {
                       let mut guard = [< CLOSURE_ $n >].lock().unwrap();
-                      if (*guard).callback == None {
+                      if (*guard).callback.is_none() {
                           panic!(
                               "No callbacks registered under this number ({}).",
                               index

--- a/raylib/src/core/camera.rs
+++ b/raylib/src/core/camera.rs
@@ -22,20 +22,20 @@ impl From<ffi::Camera3D> for Camera3D {
     }
 }
 
-impl Into<ffi::Camera3D> for Camera3D {
-    fn into(self) -> ffi::Camera3D {
-        unsafe { std::mem::transmute(self) }
+impl From<Camera3D> for ffi::Camera3D {
+    fn from(val: Camera3D) -> ffi::Camera3D {
+        unsafe { std::mem::transmute(val) }
     }
 }
 
-impl Into<ffi::Camera3D> for &Camera3D {
-    fn into(self) -> ffi::Camera3D {
+impl From<&Camera3D> for ffi::Camera3D {
+    fn from(val: &Camera3D) -> ffi::Camera3D {
         ffi::Camera3D {
-            position: self.position.into(),
-            target: self.target.into(),
-            up: self.up.into(),
-            fovy: self.fovy,
-            projection: (self.projection_ as u32) as i32,
+            position: val.position.into(),
+            target: val.target.into(),
+            up: val.up.into(),
+            fovy: val.fovy,
+            projection: (val.projection_ as u32) as i32,
         }
     }
 }
@@ -55,26 +55,26 @@ impl From<ffi::Camera2D> for Camera2D {
     }
 }
 
-impl Into<ffi::Camera2D> for Camera2D {
-    fn into(self) -> ffi::Camera2D {
-        unsafe { std::mem::transmute(self) }
+impl From<Camera2D> for ffi::Camera2D {
+    fn from(val: Camera2D) -> ffi::Camera2D {
+        unsafe { std::mem::transmute(val) }
     }
 }
 
-impl Into<ffi::Camera2D> for &Camera2D {
-    fn into(self) -> ffi::Camera2D {
+impl From<&Camera2D> for ffi::Camera2D {
+    fn from(val: &Camera2D) -> ffi::Camera2D {
         ffi::Camera2D {
-            offset: self.offset.into(),
-            target: self.target.into(),
-            rotation: self.rotation,
-            zoom: self.zoom,
+            offset: val.offset.into(),
+            target: val.target.into(),
+            rotation: val.rotation,
+            zoom: val.zoom,
         }
     }
 }
 
 impl Camera3D {
     pub fn camera_type(&self) -> crate::consts::CameraProjection {
-        unsafe { std::mem::transmute(self.projection_.clone()) }
+        self.projection_
     }
     /// Create a perspective camera.
     /// fovy is in degrees

--- a/raylib/src/core/collision.rs
+++ b/raylib/src/core/collision.rs
@@ -33,7 +33,7 @@ impl Rectangle {
         if self.check_collision_recs(other) {
             return Some(unsafe { ffi::GetCollisionRec(self.into(), other.into()).into() });
         }
-        return None;
+        None
     }
 
     /// Checks if point is inside rectangle.
@@ -81,7 +81,7 @@ pub fn check_collision_point_poly(point: Vector2, points: &[Vector2]) -> bool {
     unsafe {
         ffi::CheckCollisionPointPoly(
             point.into(),
-            std::mem::transmute(points.as_ptr()),
+            std::mem::transmute::<*const Vector2, *const ffi::Vector2>(points.as_ptr()),
             points.len() as i32,
         )
     }
@@ -128,9 +128,9 @@ pub fn check_collision_lines(
         )
     };
     if collision {
-        return Some(out.into());
+        Some(out.into())
     } else {
-        return None;
+        None
     }
 }
 

--- a/raylib/src/core/color.rs
+++ b/raylib/src/core/color.rs
@@ -1,10 +1,8 @@
 //! [`Color`] manipulation helpers
-use std::os::raw::c_void;
 
 use crate::core::math::{Vector3, Vector4};
 use crate::ffi;
 
-use raylib_sys::{ColorIsEqual, GetPixelColor, PixelFormat};
 #[cfg(not(feature = "with_serde"))]
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -16,8 +14,6 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "with_serde")]
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-
-use super::RaylibHandle;
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Default)]
@@ -40,30 +36,30 @@ impl From<ffi::Color> for Color {
     }
 }
 
-impl Into<ffi::Color> for Color {
-    fn into(self) -> ffi::Color {
-        unsafe { std::mem::transmute(self) }
+impl From<Color> for ffi::Color {
+    fn from(val: Color) -> ffi::Color {
+        unsafe { std::mem::transmute(val) }
     }
 }
 
-impl Into<ffi::Color> for &Color {
-    fn into(self) -> ffi::Color {
+impl From<&Color> for ffi::Color {
+    fn from(val: &Color) -> ffi::Color {
         ffi::Color {
-            r: self.r,
-            g: self.g,
-            b: self.b,
-            a: self.a,
+            r: val.r,
+            g: val.g,
+            b: val.b,
+            a: val.a,
         }
     }
 }
 
-impl Into<Vector4> for Color {
-    fn into(self) -> Vector4 {
+impl From<Color> for Vector4 {
+    fn from(val: Color) -> Vector4 {
         Vector4::new(
-            self.r as f32 / 255.0,
-            self.g as f32 / 255.0,
-            self.b as f32 / 255.0,
-            self.a as f32 / 255.0,
+            val.r as f32 / 255.0,
+            val.g as f32 / 255.0,
+            val.b as f32 / 255.0,
+            val.a as f32 / 255.0,
         )
     }
 }
@@ -191,7 +187,7 @@ impl Color {
 /// change or do anything different, but in the ultra rare case that it does, we want to mimick Raylib's behavior.
 impl PartialEq for Color {
     fn eq(&self, other: &Self) -> bool {
-        return self.is_equal(other);
+        self.is_equal(other)
     }
 }
 impl Eq for Color {}

--- a/raylib/src/core/data.rs
+++ b/raylib/src/core/data.rs
@@ -26,7 +26,7 @@ pub fn compress_data(data: &[u8]) -> Result<&'static [u8], Error> {
         return Err(error!("could not compress data"));
     }
     let buffer = unsafe { std::slice::from_raw_parts(buffer, out_length as usize) };
-    return Ok(buffer);
+    Ok(buffer)
 }
 
 /// Decompress data (DEFLATE algorythm)
@@ -49,7 +49,7 @@ pub fn decompress_data(data: &[u8]) -> Result<&'static [u8], Error> {
         return Err(error!("could not compress data"));
     }
     let buffer = unsafe { std::slice::from_raw_parts(buffer, out_length as usize) };
-    return Ok(buffer);
+    Ok(buffer)
 }
 
 #[cfg(unix)]
@@ -88,7 +88,7 @@ pub fn encode_data_base64(data: &[u8]) -> Vec<c_char> {
                 }
                 keep
             })
-            .map(|f| *f)
+            .copied()
             .collect();
         b
     } else {
@@ -114,7 +114,7 @@ pub fn decode_data_base64(data: &[u8]) -> Vec<u8> {
                 }
                 keep
             })
-            .map(|f| *f)
+            .copied()
             .collect();
         b
     } else {

--- a/raylib/src/core/drawing.rs
+++ b/raylib/src/core/drawing.rs
@@ -11,20 +11,19 @@ use crate::core::vr::VrStereoConfig;
 use crate::core::{RaylibHandle, RaylibThread};
 use crate::ffi;
 use crate::math::Matrix;
-use crate::models::{Mesh, WeakMaterial};
-use crate::text::Codepoints;
+use crate::models::WeakMaterial;
 use std::convert::AsRef;
 use std::ffi::CString;
 
 use super::camera::Camera2D;
-use super::shaders::{Shader, ShaderV};
+use super::shaders::Shader;
 
 /// Seems like all draw commands must be issued from the main thread
 impl RaylibHandle {
     #[must_use]
     /// Setup canvas (framebuffer) to start drawing.
     /// Prefer using the closure version, [RaylibHandle::draw]. This version returns a handle that calls [raylib_sys::EndDrawing] at the end of the scope and is provided as a fallback incase you run into issues with closures(such as lifetime or performance reasons)
-    pub fn begin_drawing(&mut self, _: &RaylibThread) -> RaylibDrawHandle {
+    pub fn begin_drawing(&mut self, _: &RaylibThread) -> RaylibDrawHandle<'_> {
         unsafe {
             ffi::BeginDrawing();
         };
@@ -48,7 +47,7 @@ pub struct RaylibDrawHandle<'a>(&'a mut RaylibHandle);
 impl<'a> RaylibDrawHandle<'a> {
     #[deprecated = "Calling begin_drawing within RaylibDrawHandle will result in a runtime error."]
     #[doc(hidden)]
-    pub fn begin_drawing(&mut self, _: &RaylibThread) -> RaylibDrawHandle {
+    pub fn begin_drawing(&mut self, _: &RaylibThread) -> RaylibDrawHandle<'_> {
         panic!("Nested begin_drawing call")
     }
     #[deprecated = "Calling draw within RaylibDrawHandle will result in a runtime error."]
@@ -70,7 +69,7 @@ impl<'a> std::ops::Deref for RaylibDrawHandle<'a> {
     type Target = RaylibHandle;
 
     fn deref(&self) -> &Self::Target {
-        &self.0
+        self.0
     }
 }
 
@@ -94,7 +93,7 @@ impl<'a, T> std::ops::Deref for RaylibTextureMode<'a, T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
-        &self.0
+        self.0
     }
 }
 impl<'a, T> std::ops::DerefMut for RaylibTextureMode<'a, T> {
@@ -115,7 +114,7 @@ where
         &'a mut self,
         _: &RaylibThread,
         framebuffer: &'a mut ffi::RenderTexture2D,
-    ) -> RaylibTextureMode<Self> {
+    ) -> RaylibTextureMode<'a, Self> {
         unsafe { ffi::BeginTextureMode(*framebuffer) }
         RaylibTextureMode(self, framebuffer)
     }
@@ -148,7 +147,7 @@ impl<'a, T> std::ops::Deref for RaylibVRMode<'a, T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
-        &self.0
+        self.0
     }
 }
 
@@ -163,7 +162,7 @@ where
         &'a mut self,
         _: &RaylibThread,
         vr_config: &'a mut VrStereoConfig,
-    ) -> RaylibVRMode<Self> {
+    ) -> RaylibVRMode<'a, Self> {
         unsafe { ffi::BeginVrStereoMode(*vr_config.as_ref()) }
         RaylibVRMode(self, vr_config)
     }
@@ -174,7 +173,7 @@ where
         mut func: impl FnMut(RaylibVRMode<Self>),
     ) {
         unsafe { ffi::BeginVrStereoMode(*vr_config.as_ref()) }
-        func(RaylibVRMode(&self, vr_config));
+        func(RaylibVRMode(self, vr_config));
     }
 }
 
@@ -193,7 +192,7 @@ impl<'a, T> std::ops::Deref for RaylibMode2D<'a, T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
-        &self.0
+        self.0
     }
 }
 impl<'a, T> std::ops::DerefMut for RaylibMode2D<'a, T> {
@@ -210,7 +209,7 @@ where
     /// Prefer using the closure version, [RaylibMode2DExt::draw_mode2D]. This version returns a handle that calls [raylib_sys::EndMode2D] at the end of the scope and is provided as a fallback incase you run into issues with closures(such as lifetime or performance reasons)
     #[allow(non_snake_case)]
     #[must_use]
-    fn begin_mode2D(&mut self, camera: impl Into<ffi::Camera2D>) -> RaylibMode2D<Self> {
+    fn begin_mode2D(&mut self, camera: impl Into<ffi::Camera2D>) -> RaylibMode2D<'_, Self> {
         unsafe {
             ffi::BeginMode2D(camera.into());
         }
@@ -248,7 +247,7 @@ impl<'a, T> std::ops::Deref for RaylibMode3D<'a, T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
-        &self.0
+        self.0
     }
 }
 impl<'a, T> std::ops::DerefMut for RaylibMode3D<'a, T> {
@@ -265,7 +264,7 @@ where
     /// Prefer using the closure version, [RaylibMode3DExt::draw_mode3D]. This version returns a handle that calls [raylib_sys::EndMode3D] at the end of the scope and is provided as a fallback incase you run into issues with closures(such as lifetime or performance reasons)
     #[allow(non_snake_case)]
     #[must_use]
-    fn begin_mode3D(&mut self, camera: impl Into<ffi::Camera3D>) -> RaylibMode3D<Self> {
+    fn begin_mode3D(&mut self, camera: impl Into<ffi::Camera3D>) -> RaylibMode3D<'_, Self> {
         unsafe {
             ffi::BeginMode3D(camera.into());
         }
@@ -305,7 +304,7 @@ impl<'a, T> std::ops::Deref for RaylibShaderMode<'a, T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
-        &self.0
+        self.0
     }
 }
 impl<'a, T> std::ops::DerefMut for RaylibShaderMode<'a, T> {
@@ -321,7 +320,7 @@ where
     /// Begin custom shader drawing.
     /// Prefer using the closure version, [RaylibShaderModeExt::draw_shader_mode]. This version returns a handle that calls [raylib_sys::EndShaderMode] at the end of the scope and is provided as a fallback incase you run into issues with closures(such as lifetime or performance reasons)
     #[must_use]
-    fn begin_shader_mode<'a>(&'a mut self, shader: &'a mut Shader) -> RaylibShaderMode<Self> {
+    fn begin_shader_mode<'a>(&'a mut self, shader: &'a mut Shader) -> RaylibShaderMode<'a, Self> {
         unsafe { ffi::BeginShaderMode(*shader.as_ref()) }
         RaylibShaderMode(self, shader)
     }
@@ -352,7 +351,7 @@ impl<'a, T> std::ops::Deref for RaylibBlendMode<'a, T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
-        &self.0
+        self.0
     }
 }
 impl<'a, T> std::ops::DerefMut for RaylibBlendMode<'a, T> {
@@ -368,7 +367,10 @@ where
     /// Begin blending mode (alpha, additive, multiplied, subtract, custom).
     /// Prefer using the closure version, [RaylibBlendModeExt::draw_blend_mode]. This version returns a handle that calls [raylib_sys::EndBlendMode] at the end of the scope and is provided as a fallback incase you run into issues with closures(such as lifetime or performance reasons)
     #[must_use]
-    fn begin_blend_mode(&mut self, blend_mode: crate::consts::BlendMode) -> RaylibBlendMode<Self> {
+    fn begin_blend_mode(
+        &mut self,
+        blend_mode: crate::consts::BlendMode,
+    ) -> RaylibBlendMode<'_, Self> {
         unsafe { ffi::BeginBlendMode((blend_mode as u32) as i32) }
         RaylibBlendMode(self)
     }
@@ -399,7 +401,7 @@ impl<'a, T> std::ops::Deref for RaylibScissorMode<'a, T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
-        &self.0
+        self.0
     }
 }
 impl<'a, T> std::ops::DerefMut for RaylibScissorMode<'a, T> {
@@ -421,7 +423,7 @@ where
         y: i32,
         width: i32,
         height: i32,
-    ) -> RaylibScissorMode<Self> {
+    ) -> RaylibScissorMode<'_, Self> {
         unsafe { ffi::BeginScissorMode(x, y, width, height) }
         RaylibScissorMode(self)
     }
@@ -708,6 +710,8 @@ pub trait RaylibDraw {
 
     /// Draw ring
     #[inline]
+    // Argument list mirrors raylib's `DrawRing` C API; refactoring would diverge from upstream.
+    #[allow(clippy::too_many_arguments)]
     fn draw_ring(
         &mut self,
         center: impl Into<ffi::Vector2>,
@@ -733,6 +737,8 @@ pub trait RaylibDraw {
 
     /// Draw ring lines
     #[inline]
+    // Argument list mirrors raylib's `DrawRingLines` C API; refactoring would diverge from upstream.
+    #[allow(clippy::too_many_arguments)]
     fn draw_ring_lines(
         &mut self,
         center: impl Into<ffi::Vector2>,
@@ -1212,6 +1218,8 @@ pub trait RaylibDraw {
         }
     }
 
+    // Argument list mirrors raylib's `DrawTextPro` C API; refactoring would diverge from upstream.
+    #[allow(clippy::too_many_arguments)]
     fn draw_text_pro(
         &mut self,
         font: impl AsRef<ffi::Font>,
@@ -1661,12 +1669,15 @@ pub trait RaylibDraw3D {
         material: WeakMaterial,
         transforms: &[Matrix],
     ) {
-        let tr = transforms
-            .iter()
-            .map(|f| f.into())
-            .collect::<Vec<ffi::Matrix>>()
-            .as_ptr();
-        unsafe { ffi::DrawMeshInstanced(*mesh.as_ref(), material.0, tr, transforms.len() as i32) }
+        let tr: Vec<ffi::Matrix> = transforms.iter().map(|f| f.into()).collect();
+        unsafe {
+            ffi::DrawMeshInstanced(
+                *mesh.as_ref(),
+                material.0,
+                tr.as_ptr(),
+                transforms.len() as i32,
+            )
+        }
     }
 
     /// Draws a sphere.
@@ -2002,6 +2013,8 @@ pub trait RaylibDraw3D {
     }
 
     /// Draw a billboard texture defined by source and rotation
+    // Argument list mirrors raylib's `DrawBillboardPro` C API; refactoring would diverge from upstream.
+    #[allow(clippy::too_many_arguments)]
     fn draw_billboard_pro(
         &mut self,
         camera: impl Into<ffi::Camera>,

--- a/raylib/src/core/input.rs
+++ b/raylib/src/core/input.rs
@@ -1,5 +1,5 @@
 //! Keyboard, Controller, and Mouse related functions
-use raylib_sys::{GamepadButton, TraceLogLevel};
+use raylib_sys::TraceLogLevel;
 
 use crate::consts::Gesture;
 use crate::core::math::Vector2;
@@ -149,7 +149,9 @@ impl RaylibHandle {
     pub fn get_gamepad_button_pressed(&self) -> Option<crate::consts::GamepadButton> {
         let button = unsafe { ffi::GetGamepadButtonPressed() };
         if button != raylib_sys::GamepadButton::GAMEPAD_BUTTON_UNKNOWN as i32 {
-            return Some(unsafe { std::mem::transmute(button as u32) });
+            return Some(unsafe {
+                std::mem::transmute::<u32, crate::consts::GamepadButton>(button as u32)
+            });
         }
         None
     }
@@ -274,7 +276,7 @@ impl RaylibHandle {
     #[inline]
     pub fn set_gestures_enabled(&self, gesture_flags: u32) {
         unsafe {
-            ffi::SetGesturesEnabled(gesture_flags as u32);
+            ffi::SetGesturesEnabled(gesture_flags);
         }
     }
 

--- a/raylib/src/core/logging.rs
+++ b/raylib/src/core/logging.rs
@@ -1,4 +1,4 @@
-///! Functions to change the behavior of raylib logging.
+//! Functions to change the behavior of raylib logging.
 // TODO: refactor this entire thing to use log
 use crate::consts::TraceLogLevel;
 use crate::{ffi, RaylibHandle};

--- a/raylib/src/core/macros.rs
+++ b/raylib/src/core/macros.rs
@@ -44,6 +44,11 @@ macro_rules! impl_wrapper {
     ($name:ident$(<$lifetime:tt>)?, $t:ty, $dropfunc:expr, $rawfield:tt) => {
         impl$(<$lifetime>)? $name$(<$lifetime>)? {
             /// Take the raw ffi type. Must manually free memory by calling the proper unload function
+            ///
+            /// # Safety
+            ///
+            /// The returned raw value is no longer managed by Rust. The caller is responsible for
+            /// freeing it via the appropriate raylib unload function; otherwise memory will leak.
             pub unsafe fn unwrap(self) -> $t {
                 let inner = self.$rawfield;
                 std::mem::forget(self);
@@ -77,6 +82,11 @@ macro_rules! gen_from_raw_wrapper {
             /// converts raylib-sys object to a "safe"
             /// version. Make sure to call this function
             /// from the thread the resource was created.
+            ///
+            /// # Safety
+            ///
+            /// The caller must ensure `raw` is a valid value produced by raylib and that Rust now
+            /// has exclusive ownership of it; otherwise double-free or use-after-free can occur.
             pub unsafe fn from_raw(raw: $t) -> Self {
                 Self(raw)
             }

--- a/raylib/src/core/misc.rs
+++ b/raylib/src/core/misc.rs
@@ -5,7 +5,6 @@ use crate::core::{RaylibHandle, RaylibThread};
 use crate::ffi;
 use std::ffi::CString;
 use std::ops::{Deref, DerefMut, Range};
-use std::usize;
 
 /// Struct for holding the result of RaylibHandle::load_random_sequence.
 /// This is a thin wrapper for an array of i32. The reason it exists is because Raylib expects you
@@ -22,7 +21,7 @@ impl<'a> Deref for RandomSequence<'a> {
 
 impl<'a> DerefMut for RandomSequence<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
+        self.0
     }
 }
 
@@ -49,10 +48,7 @@ impl<'a> Iterator for RandSeqIterator<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         let ret = self.0.get(self.1);
         self.1 += 1;
-        match ret {
-            Some(a) => Some(*a),
-            None => None,
-        }
+        ret.copied()
     }
 }
 
@@ -73,7 +69,7 @@ impl RaylibHandle {
     /// Load random values sequence, no values repeated
     pub fn load_random_sequence<'a>(&self, num: Range<i32>, count: u32) -> RandomSequence<'a> {
         unsafe {
-            let ptr = ffi::LoadRandomSequence(count, num.start, num.end.into());
+            let ptr = ffi::LoadRandomSequence(count, num.start, num.end);
             RandomSequence(std::slice::from_raw_parts_mut(ptr, count as usize))
         }
     }
@@ -99,7 +95,7 @@ impl RaylibHandle {
     ///     println!("random value: {}", r);
     /// }
     pub fn get_random_value<T: From<i32>>(&self, num: Range<i32>) -> T {
-        unsafe { (ffi::GetRandomValue(num.start, num.end.into()) as i32).into() }
+        unsafe { (ffi::GetRandomValue(num.start, num.end) as i32).into() }
     }
 
     /// Set the seed for random number generation

--- a/raylib/src/core/mod.rs
+++ b/raylib/src/core/mod.rs
@@ -203,7 +203,7 @@ impl RaylibBuilder {
         }
 
         unsafe {
-            ffi::SetConfigFlags(flags as u32);
+            ffi::SetConfigFlags(flags);
         }
 
         unsafe {

--- a/raylib/src/core/models.rs
+++ b/raylib/src/core/models.rs
@@ -133,6 +133,14 @@ impl RaylibModel for WeakModel {}
 impl RaylibModel for Model {}
 
 impl Model {
+    /// Convert into a [`WeakModel`] that does not own the underlying resource.
+    ///
+    /// # Safety
+    ///
+    /// The caller becomes responsible for ensuring the returned `WeakModel`
+    /// does not outlive the GPU resources it references, and for explicitly
+    /// unloading the model via [`RaylibHandle::unload_model`] when finished.
+    /// Failing to do so will leak GPU memory.
     pub unsafe fn make_weak(self) -> WeakModel {
         let m = WeakModel(self.0);
         std::mem::forget(self);
@@ -210,14 +218,14 @@ pub trait RaylibModel: AsRef<ffi::Model> + AsMut<ffi::Model> {
         if self.as_ref().bindPose.is_null() {
             return None;
         }
-        Some(unsafe { std::mem::transmute(self.as_ref().bindPose) })
+        Some(unsafe { &*(self.as_ref().bindPose as *const crate::math::Transform) })
     }
 
     fn bind_pose_mut(&mut self) -> Option<&mut crate::math::Transform> {
         if self.as_ref().bindPose.is_null() {
             return None;
         }
-        Some(unsafe { std::mem::transmute(self.as_mut().bindPose) })
+        Some(unsafe { &mut *(self.as_mut().bindPose as *mut crate::math::Transform) })
     }
 
     /// Check model animation skeleton match
@@ -239,13 +247,13 @@ pub trait RaylibModel: AsRef<ffi::Model> + AsMut<ffi::Model> {
     /// Set material for a mesh
     fn set_model_mesh_material(&mut self, mesh_id: i32, material_id: i32) -> Result<(), Error> {
         if mesh_id >= self.as_ref().meshCount {
-            return Err(error!("mesh_id greater than mesh count"));
+            Err(error!("mesh_id greater than mesh count"))
         } else if material_id >= self.as_ref().materialCount {
-            return Err(error!("material_id greater than material count"));
+            Err(error!("material_id greater than material count"))
         } else {
             unsafe { ffi::SetModelMeshMaterial(self.as_mut(), mesh_id, material_id) };
-            return Ok(());
-        };
+            Ok(())
+        }
     }
 }
 
@@ -253,6 +261,14 @@ impl RaylibMesh for WeakMesh {}
 impl RaylibMesh for Mesh {}
 
 impl Mesh {
+    /// Convert into a [`WeakMesh`] that does not own the underlying resource.
+    ///
+    /// # Safety
+    ///
+    /// The caller becomes responsible for ensuring the returned `WeakMesh`
+    /// does not outlive the GPU resources it references, and for explicitly
+    /// unloading the mesh via [`RaylibHandle::unload_mesh`] when finished.
+    /// Failing to do so will leak GPU memory.
     pub unsafe fn make_weak(self) -> WeakMesh {
         let m = WeakMesh(self.0);
         std::mem::forget(self);
@@ -260,9 +276,24 @@ impl Mesh {
     }
 }
 pub trait RaylibMesh: AsRef<ffi::Mesh> + AsMut<ffi::Mesh> {
+    /// Upload mesh vertex data to the GPU.
+    ///
+    /// # Safety
+    ///
+    /// Must be called on the main thread while a valid raylib context exists,
+    /// as this calls into OpenGL via raylib. The mesh's CPU-side buffers must
+    /// be valid and fully initialized.
     unsafe fn upload(&mut self, dynamic: bool) {
         ffi::UploadMesh(self.as_mut(), dynamic);
     }
+    /// Update a GPU mesh buffer with new data.
+    ///
+    /// # Safety
+    ///
+    /// Must be called on the main thread while a valid raylib context exists.
+    /// `index` must identify a valid buffer that has previously been uploaded
+    /// with [`upload`], and `offset + data.len()` must not exceed the size of
+    /// that buffer on the GPU.
     unsafe fn update_buffer<A>(&mut self, index: i32, data: &[u8], offset: i32) {
         ffi::UpdateMeshBuffer(
             *self.as_ref(),
@@ -347,7 +378,7 @@ pub trait RaylibMesh: AsRef<ffi::Mesh> + AsMut<ffi::Mesh> {
     fn indicies_mut(&mut self) -> &mut [u16] {
         unsafe {
             std::slice::from_raw_parts_mut(
-                self.as_mut().indices as *mut u16,
+                self.as_mut().indices,
                 self.as_mut().vertexCount as usize,
             )
         }
@@ -461,6 +492,14 @@ pub trait RaylibMesh: AsRef<ffi::Mesh> + AsMut<ffi::Mesh> {
 }
 
 impl Material {
+    /// Convert into a [`WeakMaterial`] that does not own the underlying resource.
+    ///
+    /// # Safety
+    ///
+    /// The caller becomes responsible for ensuring the returned `WeakMaterial`
+    /// does not outlive the GPU resources it references, and for explicitly
+    /// unloading the material via [`RaylibHandle::unload_material`] when
+    /// finished. Failing to do so will leak GPU memory.
     pub unsafe fn make_weak(self) -> WeakMaterial {
         let m = WeakMaterial(self.0);
         std::mem::forget(self);
@@ -536,6 +575,16 @@ impl RaylibModelAnimation for ModelAnimation {}
 impl RaylibModelAnimation for WeakModelAnimation {}
 
 impl ModelAnimation {
+    /// Convert into a [`WeakModelAnimation`] that does not own the underlying
+    /// resource.
+    ///
+    /// # Safety
+    ///
+    /// The caller becomes responsible for ensuring the returned
+    /// `WeakModelAnimation` does not outlive the underlying data, and for
+    /// explicitly unloading the animation via
+    /// [`RaylibHandle::unload_model_animation`] when finished. Failing to do
+    /// so will leak memory.
     pub unsafe fn make_weak(self) -> WeakModelAnimation {
         let m = WeakModelAnimation(self.0);
         std::mem::forget(self);
@@ -625,6 +674,13 @@ impl RaylibHandle {
 
     /// Weak materials will leak memeory if they are not unlaoded
     /// Unload material from GPU memory (VRAM)
+    ///
+    /// # Safety
+    ///
+    /// `material` must be a valid, currently-loaded material that has not
+    /// already been unloaded. After this call the GPU resources backing
+    /// `material` are freed, so any other `WeakMaterial` copies referring to
+    /// the same material must no longer be used.
     pub unsafe fn unload_material(&mut self, _: &RaylibThread, material: WeakMaterial) {
         {
             ffi::UnloadMaterial(*material.as_ref())
@@ -633,6 +689,13 @@ impl RaylibHandle {
 
     /// Weak models will leak memeory if they are not unlaoded
     /// Unload model from GPU memory (VRAM)
+    ///
+    /// # Safety
+    ///
+    /// `model` must be a valid, currently-loaded model that has not already
+    /// been unloaded. After this call the GPU resources backing `model` are
+    /// freed, so any other `WeakModel` copies referring to the same model
+    /// must no longer be used.
     pub unsafe fn unload_model(&mut self, _: &RaylibThread, model: WeakModel) {
         {
             ffi::UnloadModel(*model.as_ref())
@@ -641,6 +704,13 @@ impl RaylibHandle {
 
     /// Weak model_animations will leak memeory if they are not unlaoded
     /// Unload model_animation from GPU memory (VRAM)
+    ///
+    /// # Safety
+    ///
+    /// `model_animation` must be a valid, currently-loaded animation that has
+    /// not already been unloaded. After this call the memory backing
+    /// `model_animation` is freed, so any other `WeakModelAnimation` copies
+    /// referring to the same animation must no longer be used.
     pub unsafe fn unload_model_animation(
         &mut self,
         _: &RaylibThread,
@@ -653,6 +723,13 @@ impl RaylibHandle {
 
     /// Weak meshs will leak memeory if they are not unlaoded
     /// Unload mesh from GPU memory (VRAM)
+    ///
+    /// # Safety
+    ///
+    /// `mesh` must be a valid, currently-loaded mesh that has not already
+    /// been unloaded. After this call the GPU resources backing `mesh` are
+    /// freed, so any other `WeakMesh` copies referring to the same mesh must
+    /// no longer be used.
     pub unsafe fn unload_mesh(&mut self, _: &RaylibThread, mesh: WeakMesh) {
         {
             ffi::UnloadMesh(*mesh.as_ref())

--- a/raylib/src/core/shaders.rs
+++ b/raylib/src/core/shaders.rs
@@ -1,5 +1,4 @@
 //! Code for the safe manipulation of shaders
-use thiserror::Error;
 
 use crate::consts::ShaderUniformDataType;
 use crate::core::math::Matrix;
@@ -32,14 +31,12 @@ impl RaylibHandle {
         // Trust me, I have tried ALL the RUST option ergonamics. This is the only way
         // to get this to work without raylib breaking for whatever reason
         // UPDATE FOR 2024 FROM ANOTHER PERSON: Yes this is still true, doing although "for some reason" is likely due to the pointer getting freed too early if you don't do it this way.
-        let shader = match (c_vs_filename, c_fs_filename) {
+        match (c_vs_filename, c_fs_filename) {
             (Some(vs), Some(fs)) => unsafe { Shader(ffi::LoadShader(vs.as_ptr(), fs.as_ptr())) },
             (None, Some(fs)) => unsafe { Shader(ffi::LoadShader(std::ptr::null(), fs.as_ptr())) },
             (Some(vs), None) => unsafe { Shader(ffi::LoadShader(vs.as_ptr(), std::ptr::null())) },
             (None, None) => unsafe { Shader(ffi::LoadShader(std::ptr::null(), std::ptr::null())) },
-        };
-
-        return shader;
+        }
     }
 
     /// Loads shader from code strings and binds default locations.
@@ -51,7 +48,7 @@ impl RaylibHandle {
     ) -> Shader {
         let c_vs_code = vs_code.map(|f| CString::new(f).unwrap());
         let c_fs_code = fs_code.map(|f| CString::new(f).unwrap());
-        return match (c_vs_code, c_fs_code) {
+        match (c_vs_code, c_fs_code) {
             (Some(vs), Some(fs)) => unsafe {
                 Shader(ffi::LoadShaderFromMemory(
                     vs.as_ptr() as *mut c_char,
@@ -76,7 +73,7 @@ impl RaylibHandle {
                     std::ptr::null_mut(),
                 ))
             },
-        };
+        }
     }
 
     /// Get default shader. Modifying it modifies everthing that uses that shader
@@ -93,6 +90,15 @@ impl RaylibHandle {
 
 pub trait ShaderV {
     const UNIFORM_TYPE: ShaderUniformDataType;
+    /// Returns a raw pointer to the underlying data for use as a shader uniform value.
+    ///
+    /// # Safety
+    ///
+    /// The returned pointer is only valid for as long as `self` is borrowed; the
+    /// caller must not outlive `self` nor read more bytes than the underlying
+    /// type contains. The caller must also ensure the pointer is passed to a
+    /// raylib uniform-setter that matches `UNIFORM_TYPE`, otherwise the GPU
+    /// will read past the end of the allocation.
     unsafe fn value(&self) -> *const c_void;
 }
 
@@ -181,6 +187,15 @@ impl ShaderV for &[i32] {
 }
 
 impl Shader {
+    /// Converts this owned [`Shader`] into a [`WeakShader`] that will not
+    /// unload the underlying GPU resource on drop.
+    ///
+    /// # Safety
+    ///
+    /// The caller becomes responsible for manually unloading the shader via
+    /// `ffi::UnloadShader`. Failing to do so leaks GPU memory. Using the
+    /// returned `WeakShader` after the underlying shader has been unloaded is
+    /// undefined behaviour.
     pub unsafe fn make_weak(self) -> WeakShader {
         let m = WeakShader(self.0);
         std::mem::forget(self);

--- a/raylib/src/core/text.rs
+++ b/raylib/src/core/text.rs
@@ -1,6 +1,5 @@
 //! Text and Font related functions
 //! Text manipulation functions are super unsafe so use rust String functions
-use raylib_sys::LoadUTF8;
 
 use crate::core::math::Vector2;
 use crate::core::texture::{Image, Texture2D};
@@ -12,7 +11,6 @@ use crate::math::Rectangle;
 use std::convert::{AsMut, AsRef, TryInto};
 use std::ffi::{CString, OsString};
 use std::mem::ManuallyDrop;
-use std::ops::Deref;
 
 fn no_drop<T>(_thing: T) {}
 make_thin_wrapper!(Font, ffi::Font, ffi::UnloadFont);
@@ -75,13 +73,13 @@ impl std::ops::DerefMut for RSliceGlyphInfo {
 
 impl AsRef<ffi::Texture2D> for Font {
     fn as_ref(&self) -> &ffi::Texture2D {
-        return &self.0.texture;
+        &self.0.texture
     }
 }
 
 impl AsRef<ffi::Texture2D> for WeakFont {
     fn as_ref(&self) -> &ffi::Texture2D {
-        return &self.0.texture;
+        &self.0.texture
     }
 }
 
@@ -103,7 +101,7 @@ impl RaylibHandle {
 
         unsafe {
             Codepoints(std::mem::ManuallyDrop::new(Box::from_raw(
-                std::slice::from_raw_parts_mut(u, text.len()),
+                std::ptr::slice_from_raw_parts_mut(u, text.len()),
             )))
         }
     }
@@ -260,7 +258,7 @@ impl RaylibHandle {
                 None
             } else {
                 Some(RSliceGlyphInfo(std::mem::ManuallyDrop::new(Box::from_raw(
-                    std::slice::from_raw_parts_mut(ci_arr_ptr as *mut _, ci_size),
+                    std::ptr::slice_from_raw_parts_mut(ci_arr_ptr as *mut _, ci_size),
                 ))))
             }
         }
@@ -334,7 +332,7 @@ impl Font {
     pub fn make_weak(self) -> WeakFont {
         let w = WeakFont(self.0);
         std::mem::forget(self);
-        return w;
+        w
     }
     /// Returns a new `Font` using provided `GlyphInfo` data and parameters.
     fn from_data(
@@ -416,7 +414,7 @@ pub fn gen_image_font_atlas(
         recs.set_len(chars.len());
         std::ptr::copy(ptr, recs.as_mut_ptr(), chars.len());
         ffi::MemFree(ptr as *mut ::std::os::raw::c_void);
-        return (img, recs);
+        (img, recs)
     }
 }
 

--- a/raylib/src/core/texture.rs
+++ b/raylib/src/core/texture.rs
@@ -8,8 +8,6 @@ use crate::ffi;
 use std::convert::TryInto;
 use std::ffi::CString;
 use std::mem::ManuallyDrop;
-use std::os::raw::c_void;
-use std::ptr::{null, null_mut};
 
 use super::math::Vector2;
 
@@ -33,21 +31,21 @@ impl From<ffi::NPatchInfo> for NPatchInfo {
     }
 }
 
-impl Into<ffi::NPatchInfo> for NPatchInfo {
-    fn into(self) -> ffi::NPatchInfo {
-        unsafe { std::mem::transmute(self) }
+impl From<NPatchInfo> for ffi::NPatchInfo {
+    fn from(v: NPatchInfo) -> ffi::NPatchInfo {
+        unsafe { std::mem::transmute(v) }
     }
 }
 
-impl Into<ffi::NPatchInfo> for &NPatchInfo {
-    fn into(self) -> ffi::NPatchInfo {
+impl From<&NPatchInfo> for ffi::NPatchInfo {
+    fn from(v: &NPatchInfo) -> ffi::NPatchInfo {
         ffi::NPatchInfo {
-            source: self.source.into(),
-            left: self.left,
-            top: self.top,
-            right: self.right,
-            bottom: self.bottom,
-            layout: (self.layout as u32) as i32,
+            source: v.source.into(),
+            left: v.left,
+            top: v.top,
+            right: v.right,
+            bottom: v.bottom,
+            layout: (v.layout as u32) as i32,
         }
     }
 }
@@ -105,6 +103,15 @@ impl AsMut<ffi::Texture2D> for WeakRenderTexture2D {
 }
 
 impl RenderTexture2D {
+    /// Converts this owned [`RenderTexture2D`] into a [`WeakRenderTexture2D`]
+    /// that will not unload the underlying GPU resource on drop.
+    ///
+    /// # Safety
+    ///
+    /// The caller becomes responsible for manually unloading the render
+    /// texture via [`RaylibHandle::unload_render_texture`]. Failing to do so
+    /// leaks GPU memory. Using the returned weak handle after the underlying
+    /// render texture has been unloaded is undefined behaviour.
     pub unsafe fn make_weak(self) -> WeakRenderTexture2D {
         let m = WeakRenderTexture2D(self.0);
         std::mem::forget(self);
@@ -146,6 +153,15 @@ impl Image {
     pub fn mipmaps(&self) -> i32 {
         self.0.mipmaps
     }
+    /// Returns a raw pointer to the image's pixel data.
+    ///
+    /// # Safety
+    ///
+    /// The returned pointer is owned by the underlying raylib `Image` and
+    /// remains valid only until the image is dropped, reformatted, resized,
+    /// or otherwise mutated. The caller must not free the pointer, must not
+    /// read or write past the image's pixel buffer, and must ensure the image
+    /// outlives any use of the pointer.
     pub unsafe fn data(&self) -> *mut ::std::os::raw::c_void {
         self.0.data
     }
@@ -225,7 +241,7 @@ impl Image {
             let image_data = ffi::LoadImageColors(self.0);
             let image_data_len = (self.width * self.height) as usize;
             ImageColors(ManuallyDrop::new(Box::from_raw(
-                std::slice::from_raw_parts_mut(image_data as *mut _, image_data_len),
+                std::ptr::slice_from_raw_parts_mut(image_data as *mut Color, image_data_len),
             )))
         }
     }
@@ -238,7 +254,7 @@ impl Image {
             let image_data =
                 ffi::LoadImagePalette(self.0, max_palette_size as i32, &mut palette_len);
             ImagePalette(ManuallyDrop::new(Box::from_raw(
-                std::slice::from_raw_parts_mut(image_data as *mut _, palette_len as usize),
+                std::ptr::slice_from_raw_parts_mut(image_data as *mut Color, palette_len as usize),
             )))
         }
     }
@@ -746,7 +762,7 @@ impl Image {
         if self.height == 0 {
             return Err(error!("Invalid image; height == 0"));
         }
-        if self.data == null_mut() {
+        if self.data.is_null() {
             return Err(error!("Invalid image; data == null"));
         }
 
@@ -755,11 +771,11 @@ impl Image {
         let data = unsafe { ffi::ExportImageToMemory(self.0, c_filetype.as_ptr(), data_size) };
 
         // The actual function returns null if the code for converting to a file type never goes off.
-        if data == null_mut() {
+        if data.is_null() {
             return Err(error!("Unsupported format."));
         }
 
-        return Ok(unsafe { std::slice::from_raw_parts(data as *const u8, *data_size as usize) });
+        Ok(unsafe { std::slice::from_raw_parts(data as *const u8, *data_size as usize) })
     }
 
     /// Apply custom square convolution kernel to image
@@ -771,7 +787,7 @@ impl Image {
         if self.height == 0 {
             return Err(error!("Invalid image; height == 0"));
         }
-        if self.data == null_mut() {
+        if self.data.is_null() {
             return Err(error!("Invalid image; data == null"));
         }
 
@@ -1027,6 +1043,15 @@ impl RaylibTexture2D for WeakRenderTexture2D {}
 impl RaylibTexture2D for RenderTexture2D {}
 
 impl Texture2D {
+    /// Converts this owned [`Texture2D`] into a [`WeakTexture2D`] that will
+    /// not unload the underlying GPU resource on drop.
+    ///
+    /// # Safety
+    ///
+    /// The caller becomes responsible for manually unloading the texture via
+    /// [`RaylibHandle::unload_texture`]. Failing to do so leaks GPU memory.
+    /// Using the returned weak handle after the underlying texture has been
+    /// unloaded is undefined behaviour.
     pub unsafe fn make_weak(self) -> WeakTexture2D {
         let m = WeakTexture2D(self.0);
         std::mem::forget(self);
@@ -1044,7 +1069,7 @@ pub trait RaylibTexture2D: AsRef<ffi::Texture2D> + AsMut<ffi::Texture2D> {
     }
 
     fn mipmaps(&self) -> i32 {
-        self.as_ref().width
+        self.as_ref().mipmaps
     }
 
     fn format(&self) -> i32 {
@@ -1212,6 +1237,13 @@ impl RaylibHandle {
 impl RaylibHandle {
     /// Weak Textures will leak memeory if they are not unlaoded
     /// Unload textures from GPU memory (VRAM)
+    ///
+    /// # Safety
+    ///
+    /// The given [`WeakTexture2D`] must reference a live GPU texture that has
+    /// not already been unloaded, and must not be used after this call. Passing
+    /// a handle whose underlying texture was already freed, or using the
+    /// handle again afterwards, is undefined behaviour.
     pub unsafe fn unload_texture(&mut self, _: &RaylibThread, texture: WeakTexture2D) {
         {
             ffi::UnloadTexture(*texture.as_ref())
@@ -1219,6 +1251,13 @@ impl RaylibHandle {
     }
     /// Weak RenderTextures will leak memeory if they are not unlaoded
     /// Unload RenderTextures from GPU memory (VRAM)
+    ///
+    /// # Safety
+    ///
+    /// The given [`WeakRenderTexture2D`] must reference a live GPU render
+    /// texture that has not already been unloaded, and must not be used after
+    /// this call. Passing a handle whose underlying render texture was already
+    /// freed, or using the handle again afterwards, is undefined behaviour.
     pub unsafe fn unload_render_texture(&mut self, _: &RaylibThread, texture: WeakRenderTexture2D) {
         {
             ffi::UnloadRenderTexture(*texture.as_ref())

--- a/raylib/src/core/vr.rs
+++ b/raylib/src/core/vr.rs
@@ -28,24 +28,24 @@ impl From<ffi::VrDeviceInfo> for VrDeviceInfo {
     }
 }
 
-impl Into<ffi::VrDeviceInfo> for VrDeviceInfo {
-    fn into(self) -> ffi::VrDeviceInfo {
-        unsafe { std::mem::transmute(self) }
+impl From<VrDeviceInfo> for ffi::VrDeviceInfo {
+    fn from(val: VrDeviceInfo) -> ffi::VrDeviceInfo {
+        unsafe { std::mem::transmute(val) }
     }
 }
 
-impl Into<ffi::VrDeviceInfo> for &VrDeviceInfo {
-    fn into(self) -> ffi::VrDeviceInfo {
+impl From<&VrDeviceInfo> for ffi::VrDeviceInfo {
+    fn from(val: &VrDeviceInfo) -> ffi::VrDeviceInfo {
         ffi::VrDeviceInfo {
-            hResolution: self.h_resolution,  // Horizontal resolution in pixels
-            vResolution: self.v_esolution,   // Vertical resolution in pixels
-            hScreenSize: self.h_screen_size, // Horizontal size in meters
-            vScreenSize: self.v_screen_size, // Vertical size in meters
-            eyeToScreenDistance: self.eye_to_screen_distance, // Distance between eye and display in meters
-            lensSeparationDistance: self.lens_separation_distance, // Lens separation distance in meters
-            interpupillaryDistance: self.interpupillary_distance, // IPD (distance between pupils) in meters
-            lensDistortionValues: self.lens_distortion_values, // Lens distortion constant parameters
-            chromaAbCorrection: self.chroma_ab_correction,
+            hResolution: val.h_resolution,  // Horizontal resolution in pixels
+            vResolution: val.v_esolution,   // Vertical resolution in pixels
+            hScreenSize: val.h_screen_size, // Horizontal size in meters
+            vScreenSize: val.v_screen_size, // Vertical size in meters
+            eyeToScreenDistance: val.eye_to_screen_distance, // Distance between eye and display in meters
+            lensSeparationDistance: val.lens_separation_distance, // Lens separation distance in meters
+            interpupillaryDistance: val.interpupillary_distance, // IPD (distance between pupils) in meters
+            lensDistortionValues: val.lens_distortion_values, // Lens distortion constant parameters
+            chromaAbCorrection: val.chroma_ab_correction,
         }
     }
 }

--- a/raylib/src/core/window.rs
+++ b/raylib/src/core/window.rs
@@ -818,6 +818,13 @@ impl RaylibHandle {
     }
 
     /// Get native window handle
+    ///
+    /// # Safety
+    /// The returned pointer is an opaque OS-specific handle (e.g. `HWND` on Windows,
+    /// `Window` on X11). The caller must know the correct platform type and must
+    /// ensure the raylib window is still alive for the duration the handle is used.
+    /// Dereferencing or passing it to an OS API after the window has been closed is
+    /// undefined behavior.
     #[inline]
     pub unsafe fn get_window_handle(&mut self) -> *mut ::std::os::raw::c_void {
         ffi::GetWindowHandle()

--- a/raylib/src/ease.rs
+++ b/raylib/src/ease.rs
@@ -208,9 +208,9 @@ pub fn expo_in_out(t: f32, b: f32, c: f32, d: f32) -> f32 {
 
     let td = t / (d / 2.0);
     if td < 1.0 {
-        return c / 2.0 * 2.0f32.powf(10.0 * (t - 1.0)) + b;
+        c / 2.0 * 2.0f32.powf(10.0 * (t - 1.0)) + b
     } else {
-        return c / 2.0 * (-(2.0f32.powf(-10.0 * td - 1.0)) + 2.0) + b;
+        c / 2.0 * (-(2.0f32.powf(-10.0 * td - 1.0)) + 2.0) + b
     }
 }
 

--- a/raylib/src/lib.rs
+++ b/raylib/src/lib.rs
@@ -69,13 +69,10 @@ pub mod ffi {
 }
 
 pub use crate::core::collision::*;
-pub use crate::core::logging::*;
 pub use crate::core::misc::open_url;
 pub use crate::core::*;
 
 // Re-exports
-#[cfg(feature = "nalgebra_interop")]
-pub use nalgebra as na;
 #[cfg(feature = "with_serde")]
 pub use serde;
 

--- a/raylib/src/prelude.rs
+++ b/raylib/src/prelude.rs
@@ -35,7 +35,6 @@ pub use crate::core::data::*;
 pub use crate::core::drawing::*;
 pub use crate::core::file::*;
 pub use crate::core::input::*;
-pub use crate::core::logging::*;
 pub use crate::core::math::*;
 pub use crate::core::misc::*;
 pub use crate::core::models::*;

--- a/raylib/src/rgui/safe.rs
+++ b/raylib/src/rgui/safe.rs
@@ -475,7 +475,7 @@ pub trait RaylibDrawGui {
         subdivs: i32,
     ) -> (bool, Vector2) {
         let c_text = CString::new(text).unwrap();
-        let mut mouseCell = ffi::Vector2 { x: 0.0, y: 0.0 };
+        let mut mouse_cell = ffi::Vector2 { x: 0.0, y: 0.0 };
         (
             unsafe {
                 ffi::GuiGrid(
@@ -483,10 +483,10 @@ pub trait RaylibDrawGui {
                     c_text.as_ptr(),
                     spacing,
                     subdivs,
-                    &mut mouseCell,
+                    &mut mouse_cell,
                 ) > 0
             },
-            mouseCell.into(),
+            mouse_cell.into(),
         )
     }
     /// List View control, returns selected list item index
@@ -552,6 +552,9 @@ pub trait RaylibDrawGui {
         }
     }
     /// Text Input Box control, ask for text
+    // Mirrors raylib's `GuiTextInputBox` which takes the same number of parameters;
+    // splitting would require changing the public API shape.
+    #[allow(clippy::too_many_arguments)]
     #[inline]
     fn gui_text_input_box(
         &mut self,
@@ -564,11 +567,11 @@ pub trait RaylibDrawGui {
         secret_view_active: &mut bool,
     ) -> i32 {
         // rgui.h: line 3699 MAX_FILENAME_LEN
-        text.reserve((256 - text.len()).max(0) as usize);
+        text.reserve(256usize.saturating_sub(text.len()));
         let c_title = CString::new(title).unwrap();
         let c_message = CString::new(message).unwrap();
         let c_buttons = CString::new(buttons).unwrap();
-        let btn_index = unsafe {
+        unsafe {
             ffi::GuiTextInputBox(
                 bounds.into(),
                 c_title.as_ptr(),
@@ -578,9 +581,7 @@ pub trait RaylibDrawGui {
                 text_max_size,
                 secret_view_active,
             )
-        };
-
-        btn_index
+        }
     }
 
     /// Color Picker control
@@ -594,8 +595,8 @@ pub trait RaylibDrawGui {
         let mut out = color.into();
         let c_text = CString::new(text).unwrap();
 
-        let result = unsafe { ffi::GuiColorPicker(bounds.into(), c_text.as_ptr(), &mut out) };
-        return out.into();
+        let _result = unsafe { ffi::GuiColorPicker(bounds.into(), c_text.as_ptr(), &mut out) };
+        out.into()
     }
     // Get text with icon id prepended
     // NOTE: Useful to add icons by name id (enum) instead of
@@ -672,6 +673,9 @@ pub trait RaylibDrawGui {
     note = "As of Raylib 5.5, raygui functions that once took \"property enum as i32\" now just take the enum."
 )]
 pub trait GuiProperty {
+    // `self` by value is intentional: all implementors are `Copy` enums that use
+    // `self as i32` (an enum-to-int cast), which requires an owned value.
+    #[allow(clippy::wrong_self_convention)]
     fn as_i32(self) -> i32;
 }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.95.0"
+components = ["rustfmt", "clippy"]
+profile = "minimal"

--- a/samples/Cargo.toml
+++ b/samples/Cargo.toml
@@ -103,3 +103,11 @@ required-features = ["imgui"]
 name = "music_effects"
 path = "music_effects.rs"
 required-features = ["ringbuf"]
+
+# samples is excluded from the workspace, so we declare lints locally
+# (matching the workspace `[workspace.lints]` in the repo root Cargo.toml).
+[lints.rust]
+warnings = "deny"
+
+[lints.clippy]
+all = { level = "deny", priority = -1 }

--- a/samples/rgui.rs
+++ b/samples/rgui.rs
@@ -16,12 +16,12 @@ use raylib::prelude::*;
 pub fn main() {
     // Initialization
     //---------------------------------------------------------------------------------------
-    let screenWidth = 960;
-    let screenHeight = 560;
+    let screen_width = 960;
+    let screen_height = 560;
 
     let (mut rl, thread) = raylib::init()
-        .width(screenWidth)
-        .height(screenHeight)
+        .width(screen_width)
+        .height(screen_height)
         .title("raygui - controls test suite")
         .build();
 
@@ -29,31 +29,31 @@ pub fn main() {
 
     // GUI controls initialization
     //----------------------------------------------------------------------------------
-    let mut dropdownBox000Active = 0;
-    let mut dropDown000EditMode = false;
+    let mut dropdown_box000_active = 0;
+    let mut drop_down000_edit_mode = false;
 
-    let mut dropdownBox001Active = 0;
-    let mut dropDown001EditMode = false;
+    let mut dropdown_box001_active = 0;
+    let mut drop_down001_edit_mode = false;
 
-    let mut spinner001Value = 0;
-    let mut spinnerEditMode = false;
+    let mut spinner001_value = 0;
+    let mut spinner_edit_mode = false;
 
-    let mut valueBox002Value = 0;
-    let mut valueBoxEditMode = false;
+    let mut value_box002_value = 0;
+    let mut value_box_edit_mode = false;
 
-    let mut textBoxText = String::from("Text box");
-    let mut textBoxEditMode = false;
+    let mut text_box_text = String::from("Text box");
+    let mut text_box_edit_mode = false;
 
-    let mut textBoxMultiText = String::from("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.\n\nDuis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat Nonea pariatur.\n\nThisisastringlongerthanexpectedwithoutspacestotestcharbreaksforthosecases,checkingifworkingasexpected.\n\nExcepteur slet occaecatcupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.");
-    let mut textBoxMultiEditMode = false;
+    let mut text_box_multi_text = String::from("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.\n\nDuis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat Nonea pariatur.\n\nThisisastringlongerthanexpectedwithoutspacestotestcharbreaksforthosecases,checkingifworkingasexpected.\n\nExcepteur slet occaecatcupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.");
+    let mut text_box_multi_edit_mode = false;
 
-    let mut listViewScrollIndex = 0;
-    let mut listViewActive = -1;
+    let mut list_view_scroll_index = 0;
+    let mut list_view_active = -1;
 
-    let mut listViewExScrollIndex = 0;
-    let mut listViewExActive = 2;
-    let mut listViewExFocus = -1;
-    let mut listViewExList = [
+    let mut list_view_ex_scroll_index = 0;
+    let mut list_view_ex_active = 2;
+    let mut list_view_ex_focus = -1;
+    let list_view_ex_list = [
         "This",
         "is",
         "a",
@@ -64,36 +64,35 @@ pub fn main() {
         "amazing!",
     ];
 
-    let colorPickerValue = Color::RED;
+    let color_picker_value = Color::RED;
 
-    let mut sliderValue = 50.0;
-    let mut sliderBarValue = 60.0;
-    let mut progressValue = 0.1;
+    let mut slider_value = 50.0;
+    let mut slider_bar_value = 60.0;
+    let mut progress_value = 0.1;
 
-    let mut forceSquaredChecked = false;
+    let mut force_squared_checked = false;
 
-    let mut alphaValue = 0.5;
+    let mut alpha_value = 0.5;
 
     //let comboBoxActive= 1;
-    let mut visualStyleActive = 0;
-    let mut prevVisualStyleActive = 0;
+    let mut visual_style_active = 0;
+    let mut prev_visual_style_active = 0;
 
-    let mut toggleGroupActive = 0;
-    let mut toggleSliderActive = 0;
+    let mut toggle_group_active = 0;
+    let mut toggle_slider_active = 0;
 
-    let viewScroll = Vector2::new(0.0, 0.0);
+    let view_scroll = Vector2::new(0.0, 0.0);
     //----------------------------------------------------------------------------------
 
     // Custom GUI font loading
     //Font font = LoadFontEx("fonts/rainyhearts16.ttf", 12, 0, 0);
     //GuiSetFont(font);
 
-    let mut exitWindow = false;
-    let mut showMessageBox = false;
+    let mut exit_window = false;
+    let mut show_message_box = false;
 
-    let mut textInput = String::new();
-    let mut textInputFileName = String::new();
-    let mut showTextInputBox = false;
+    let mut text_input = String::new();
+    let mut show_text_input_box = false;
 
     let mut alpha = 1.0;
 
@@ -105,26 +104,26 @@ pub fn main() {
     //--------------------------------------------------------------------------------------
 
     // Main game loop
-    while !exitWindow
+    while !exit_window
     // Detect window close button or ESC key
     {
         // Update
         //----------------------------------------------------------------------------------
-        exitWindow = rl.window_should_close();
+        exit_window = rl.window_should_close();
 
         if rl.is_key_pressed(KEY_ESCAPE) {
-            showMessageBox = !showMessageBox
+            show_message_box = !show_message_box
         };
 
         if rl.is_key_down(KEY_LEFT_CONTROL) && rl.is_key_pressed(KEY_S) {
-            showTextInputBox = true
+            show_text_input_box = true
         };
 
         if rl.is_file_dropped() {
-            let droppedFiles = rl.load_dropped_files();
+            let dropped_files = rl.load_dropped_files();
 
-            let paths = droppedFiles.paths();
-            if droppedFiles.count > 0 && paths[0].ends_with(".rgs") {
+            let paths = dropped_files.paths();
+            if dropped_files.count > 0 && paths[0].ends_with(".rgs") {
                 rl.gui_load_style(paths[0])
             };
         }
@@ -142,22 +141,22 @@ pub fn main() {
         //progressValue += 0.002;
         if rl.is_key_pressed(KEY_LEFT) {
             {
-                progressValue -= 0.1
+                progress_value -= 0.1
             };
         } else if rl.is_key_pressed(KEY_RIGHT) {
             {
-                progressValue += 0.1
+                progress_value += 0.1
             };
         }
-        if progressValue > 1.0 {
-            progressValue = 1.0;
-        } else if progressValue < 0.0 {
+        if progress_value > 1.0 {
+            progress_value = 1.0;
+        } else if progress_value < 0.0 {
             {
-                progressValue = 0.0
+                progress_value = 0.0
             };
         }
 
-        if visualStyleActive != prevVisualStyleActive {
+        if visual_style_active != prev_visual_style_active {
             rl.gui_load_style_default();
 
             // switch (visualStyleActive)
@@ -174,7 +173,7 @@ pub fn main() {
 
             rl.gui_set_style(LABEL, TEXT_ALIGNMENT, TEXT_ALIGN_LEFT as i32);
 
-            prevVisualStyleActive = visualStyleActive;
+            prev_visual_style_active = visual_style_active;
         }
         //----------------------------------------------------------------------------------
 
@@ -191,7 +190,7 @@ pub fn main() {
         // raygui: controls drawing
         //----------------------------------------------------------------------------------
         // Check all possible events that require d.gui_lock
-        if dropDown000EditMode || dropDown001EditMode {
+        if drop_down000_edit_mode || drop_down001_edit_mode {
             d.gui_lock()
         };
 
@@ -200,7 +199,7 @@ pub fn main() {
         d.gui_check_box(
             Rectangle::new(25.0, 108.0, 15.0, 15.0),
             "FORCE CHECK!",
-            &mut forceSquaredChecked,
+            &mut force_squared_checked,
         );
 
         d.gui_set_style(TEXTBOX, TEXT_ALIGNMENT, TEXT_ALIGN_CENTER as i32);
@@ -208,30 +207,30 @@ pub fn main() {
         if d.gui_spinner(
             Rectangle::new(25.0, 135.0, 125.0, 30.0),
             "",
-            &mut spinner001Value,
+            &mut spinner001_value,
             0,
             100,
-            spinnerEditMode,
+            spinner_edit_mode,
         ) {
-            spinnerEditMode = !spinnerEditMode
+            spinner_edit_mode = !spinner_edit_mode
         };
         if d.gui_value_box(
             Rectangle::new(25.0, 175.0, 125.0, 30.0),
             "",
-            &mut valueBox002Value,
+            &mut value_box002_value,
             0,
             100,
-            valueBoxEditMode,
+            value_box_edit_mode,
         ) {
-            valueBoxEditMode = !valueBoxEditMode
+            value_box_edit_mode = !value_box_edit_mode
         };
         d.gui_set_style(TEXTBOX, TEXT_ALIGNMENT, TEXT_ALIGN_LEFT as i32);
         if d.gui_text_box(
             Rectangle::new(25.0, 215.0, 125.0, 30.0),
-            &mut textBoxText,
-            textBoxEditMode,
+            &mut text_box_text,
+            text_box_edit_mode,
         ) {
-            textBoxEditMode = !textBoxEditMode
+            text_box_edit_mode = !text_box_edit_mode
         };
 
         d.gui_set_style(BUTTON, TEXT_ALIGNMENT, TEXT_ALIGN_CENTER as i32);
@@ -241,7 +240,7 @@ pub fn main() {
             Rectangle::new(25.0, 255.0, 125.0, 30.0),
             gui_icon_text.as_str(),
         ) {
-            showTextInputBox = true
+            show_text_input_box = true
         };
 
         d.gui_group_box(Rectangle::new(25.0, 310.0, 125.0, 150.0), "STATES");
@@ -260,7 +259,7 @@ pub fn main() {
         d.gui_combo_box(
             Rectangle::new(25.0, 480.0, 125.0, 30.0),
             "default;Jungle;Lavanda;Dark;Bluish;Cyber;Terminal",
-            &mut visualStyleActive,
+            &mut visual_style_active,
         );
 
         // NOTE: d.gui_dropdown_box must draw after any other control that can be covered on unfolding
@@ -270,10 +269,10 @@ pub fn main() {
         if d.gui_dropdown_box(
             Rectangle::new(25.0, 65.0, 125.0, 30.0),
             "#01#ONE;#02#TWO;#03#THREE;#04#FOUR",
-            &mut dropdownBox001Active,
-            dropDown001EditMode,
+            &mut dropdown_box001_active,
+            drop_down001_edit_mode,
         ) {
-            dropDown001EditMode = !dropDown001EditMode
+            drop_down001_edit_mode = !drop_down001_edit_mode
         };
         d.gui_set_style(DROPDOWNBOX, TEXT_ALIGNMENT, TEXT_ALIGN_CENTER as i32);
         d.gui_set_style(DROPDOWNBOX, TEXT_PADDING, 0);
@@ -281,39 +280,39 @@ pub fn main() {
         if d.gui_dropdown_box(
             Rectangle::new(25.0, 25.0, 125.0, 30.0),
             "ONE;TWO;THREE",
-            &mut dropdownBox000Active,
-            dropDown000EditMode,
+            &mut dropdown_box000_active,
+            drop_down000_edit_mode,
         ) {
-            dropDown000EditMode = !dropDown000EditMode
+            drop_down000_edit_mode = !drop_down000_edit_mode
         };
 
         // Second GUI column
         d.gui_list_view(
             Rectangle::new(165.0, 25.0, 140.0, 124.0),
             "Charmander;Bulbasaur;#18#Squirtel;Pikachu;Eevee;Pidgey",
-            &mut listViewScrollIndex,
-            &mut listViewActive,
+            &mut list_view_scroll_index,
+            &mut list_view_active,
         );
         d.gui_list_view_ex(
             Rectangle::new(165.0, 162.0, 140.0, 184.0),
-            listViewExList.iter(),
-            &mut listViewExScrollIndex,
-            &mut listViewExActive,
-            &mut listViewExFocus,
+            list_view_ex_list.iter(),
+            &mut list_view_ex_scroll_index,
+            &mut list_view_ex_active,
+            &mut list_view_ex_focus,
         );
 
         //GuiToggle(Rectangle::new( 165, 400, 140, 25 ), "#1#ONE", &toggleGroupActive);
         d.gui_toggle_group(
             Rectangle::new(165.0, 360.0, 140.0, 24.0),
             "#1#ONE\n#3#TWO\n#8#THREE\n#23#",
-            &mut toggleGroupActive,
+            &mut toggle_group_active,
         );
         //d.gui_disable();
         d.gui_set_style(SLIDER, SLIDER_PADDING, 2);
         d.gui_toggle_slider(
             Rectangle::new(165.0, 480.0, 140.0, 30.0),
             "ON;OFF",
-            &mut toggleSliderActive,
+            &mut toggle_slider_active,
         );
         d.gui_set_style(SLIDER, SLIDER_PADDING, 0);
 
@@ -322,23 +321,23 @@ pub fn main() {
         d.gui_color_picker(
             Rectangle::new(320.0, 185.0, 196.0, 192.0),
             "",
-            &colorPickerValue,
+            &color_picker_value,
         );
 
         //d.gui_disable();
         d.gui_slider(
             Rectangle::new(355.0, 400.0, 165.0, 20.0),
             "TEST",
-            format!("{}", sliderValue).as_str(),
-            &mut sliderValue,
+            format!("{}", slider_value).as_str(),
+            &mut slider_value,
             -50.0,
             100.0,
         );
         d.gui_slider_bar(
             Rectangle::new(320.0, 430.0, 200.0, 20.0),
             "",
-            format!("{}", sliderBarValue).as_str(),
-            &mut sliderBarValue,
+            format!("{}", slider_bar_value).as_str(),
+            &mut slider_bar_value,
             0.0,
             100.0,
         );
@@ -346,8 +345,8 @@ pub fn main() {
         d.gui_progress_bar(
             Rectangle::new(320.0, 460.0, 200.0, 20.0),
             "",
-            format!("{}", (progressValue * 100.0)).as_str(),
-            &mut progressValue,
+            format!("{}", (progress_value * 100.0)).as_str(),
+            &mut progress_value,
             0.0,
             1.0,
         );
@@ -359,11 +358,10 @@ pub fn main() {
             Rectangle::new(560.0, 25.0, 102.0, 354.0),
             "",
             Rectangle::new(560.0, 25.0, 300.0, 1200.0),
-            &viewScroll,
+            &view_scroll,
             &view,
         );
 
-        let mouseCell = Vector2::new(0.0, 0.0);
         d.gui_grid(
             Rectangle::new(560.0, 25.0 + 180.0 + 195.0, 100.0, 120.0),
             "",
@@ -374,17 +372,17 @@ pub fn main() {
         d.gui_color_bar_alpha(
             Rectangle::new(320.0, 490.0, 200.0, 30.0),
             "",
-            &mut alphaValue,
+            &mut alpha_value,
         );
 
         d.gui_set_style(DEFAULT, TEXT_ALIGNMENT_VERTICAL, TEXT_ALIGN_TOP as i32); // WARNING: Word-wrap does not work as expected in case of no-top alignment
         d.gui_set_style(DEFAULT, TEXT_WRAP_MODE, TEXT_WRAP_WORD as i32); // WARNING: If wrap mode enabled, text editing is not supported
         if d.gui_text_box(
             Rectangle::new(678.0, 25.0, 258.0, 492.0),
-            &mut textBoxMultiText,
-            textBoxMultiEditMode,
+            &mut text_box_multi_text,
+            text_box_multi_edit_mode,
         ) {
-            textBoxMultiEditMode = !textBoxMultiEditMode
+            text_box_multi_edit_mode = !text_box_multi_edit_mode
         };
         d.gui_set_style(DEFAULT, TEXT_WRAP_MODE, TEXT_WRAP_NONE as i32);
         d.gui_set_style(DEFAULT, TEXT_ALIGNMENT_VERTICAL, TEXT_ALIGN_MIDDLE as i32);
@@ -402,13 +400,13 @@ pub fn main() {
         d.gui_set_style(DEFAULT, TEXT_ALIGNMENT, TEXT_ALIGN_CENTER as i32);
         //d.gui_set_style(STATUSBAR, TEXT_INDENTATION, 20);
 
-        if showMessageBox {
+        if show_message_box {
             d.draw_rectangle(
                 0,
                 0,
                 d.get_screen_width(),
                 d.get_screen_height(),
-                Color::RAYWHITE.fade(0.8),
+                Color::RAYWHITE.alpha(0.8),
             );
             let gui_icon_text = d.gui_icon_text(ICON_EXIT, "Close Window");
             let result = d.gui_message_box(
@@ -424,19 +422,19 @@ pub fn main() {
             );
 
             if result == 0 || (result == 2) {
-                showMessageBox = false
+                show_message_box = false
             } else if result == 1 {
-                exitWindow = true
+                exit_window = true
             };
         }
 
-        if showTextInputBox {
+        if show_text_input_box {
             d.draw_rectangle(
                 0,
                 0,
                 d.get_screen_width(),
                 d.get_screen_height(),
-                Color::RAYWHITE.fade(0.8),
+                Color::RAYWHITE.alpha(0.8),
             );
             let mut _act = true;
             let gui_icon_text = d.gui_icon_text(ICON_FILE_SAVE, "Save file as...");
@@ -450,19 +448,14 @@ pub fn main() {
                 gui_icon_text.as_str(),
                 "Introduce output file name:",
                 "Ok;Cancel",
-                &mut textInput,
+                &mut text_input,
                 255,
                 &mut _act,
             );
 
-            if result == 1 {
-                // TODO: Validate textInput value and save
-                textInputFileName = textInput.clone();
-            }
-
             if result == 0 || (result == 1 || (result == 2)) {
-                showTextInputBox = false;
-                textInput.truncate(0);
+                show_text_input_box = false;
+                text_input.truncate(0);
             }
         }
     }


### PR DESCRIPTION
This addresses various warnings from clippy and makes it so that CI and
`just ok` fails if there are formatting issues to help ensure
consistency and clean code.
