### PR TITLE
feat: add `window_highdpi` to RaylibBuilder & `highdpi` builder func

### DIFF
--- a/raylib/src/core/mod.rs
+++ b/raylib/src/core/mod.rs
@@ -81,6 +81,7 @@ pub struct RaylibBuilder {
     window_resizable: bool,
     window_undecorated: bool,
     window_transparent: bool,
+    window_highdpi: bool,
     msaa_4x_hint: bool,
     vsync_hint: bool,
     log_level: TraceLogLevel,
@@ -128,6 +129,13 @@ impl RaylibBuilder {
     /// Sets the window to be transparent.
     pub fn transparent(&mut self) -> &mut Self {
         self.window_transparent = true;
+        self
+    }
+
+    /// Sets the window to scale for high DPI displays. Can fix small windows on
+    /// certain operating systems when using fractional scaling.
+    pub fn highdpi(&mut self) -> &mut Self {
+        self.window_highdpi = true;
         self
     }
 
@@ -194,6 +202,9 @@ impl RaylibBuilder {
         }
         if self.window_transparent {
             flags |= FLAG_WINDOW_TRANSPARENT as u32;
+        }
+        if self.window_highdpi {
+            flags |= FLAG_WINDOW_HIGHDPI as u32;
         }
         if self.msaa_4x_hint {
             flags |= FLAG_MSAA_4X_HINT as u32;


### PR DESCRIPTION
Removes the need to use the `unsafe` approach to setting the High DPI
flag.
