### PR TITLE
fix(rgui): correct gui_list_view_ex params

### DIFF
--- a/raylib/src/rgui/safe.rs
+++ b/raylib/src/rgui/safe.rs
@@ -507,9 +507,9 @@ pub trait RaylibDrawGui {
         &mut self,
         bounds: impl Into<ffi::Rectangle>,
         text: impl Iterator<Item = impl AsRef<str>>,
-        focus: &mut i32,
         scroll_index: &mut i32,
         active: &mut i32,
+        focus: &mut i32,
     ) -> i32 {
         // We need to keep track of all CStr buffers.
         let buffer: Box<[Box<CStr>]> = text
@@ -524,9 +524,9 @@ pub trait RaylibDrawGui {
                 bounds.into(),
                 text_params.as_mut_ptr(),
                 text_params.len() as i32,
-                focus,
                 scroll_index,
                 active,
+                focus,
             )
         }
     }


### PR DESCRIPTION
The C function expects `scrollIndex`, `active`, `focus`. The previous
implementation of the Rust function led to buggy behavior when using the
function.

Ref: https://github.com/raysan5/raygui/blob/3b2855842ab578a034f827c38cf8f62c042fc983/src/raygui.h#L806
