### PR TITLE
chore: port upstream bugfixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
             libgl1-mesa-dev
 
       - name: Build workspace
-        run: cargo build --workspace
+        run: cargo build --workspace --all-targets
 
       - name: Clippy
         run: cargo clippy --workspace --all-targets
@@ -66,4 +66,4 @@ jobs:
 
       - name: Build examples
         working-directory: examples
-        run: cargo build
+        run: cargo build --all-targets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,62 @@
 
 ## [Unreleased] - 5.5.3
 
+Doc improvements and bug fixes ported from upstream raylib-rs, scoped to
+soundness and correctness. Thanks to all the original authors linked below.
+
+### Breaking
+
+- `Image::export_image_to_memory` now returns `Result<Vec<u8>, Error>` instead
+  of `Result<&[u8], Error>`. The previous signature leaked on every call
+  (raylib's buffer was never freed) and had an unsound lifetime. Adapted from
+  raylib-rs [#250][rr-250] / [#247][rr-247].
+
+### Deprecated
+
+- `RaylibMesh::indicies` / `indicies_mut` — use `indices` / `indices_mut`. The
+  typo'd names stay through 5.x and are removed in 6.0.
+
+### Fixed
+
+- **Soundness:** `RaylibMesh` accessors return an empty slice when the
+  underlying buffer is null instead of invoking UB via
+  `slice::from_raw_parts(null, _)` ([raylib-rs#257][rr-257]).
+- **Soundness:** `RaylibMesh::indices` length is now `triangleCount * 3` (what
+  raylib allocates) rather than `vertexCount` ([raylib-rs#257][rr-257]).
+- **Soundness:** `Sound::alias` lifetimes correctly bind the sound's lifetime to
+  the receiver ([`4d53bd4`][rr-4d53bd4]).
+- **Use-after-free:** `load_model_animations` frees only the outer array via
+  `MemFree`, rather than `UnloadModelAnimations` which also tore down the
+  animations the `Vec` had just taken ownership of ([`ccc0827`][rr-ccc0827]).
+- **Data corruption:** `AudioStream::update` passes element count (not byte
+  size) to `ffi::UpdateAudioStream`, matching the C API
+  ([raylib-rs#212][rr-212]).
+- `Texture2D::update_texture_rec` validates the destination rectangle and sizes
+  the expected pixel buffer from rect dimensions ([`cb0c004`][rr-cb0c004]).
+- Closure-based draw helpers (`draw`, `draw_mode2D`, etc.) no longer call
+  `ffi::End*()` twice — the handle's `Drop` already does
+  ([`aadf1a7`][rr-aadf1a7]).
+- `gui_text_box` and `gui_text_input_box` grow the buffer and round-trip the
+  null terminator, so text input works ([`e2be94b`][rr-e2be94b]).
+- `gui_panel` passes a null pointer for empty strings, matching `GuiPanel`'s C
+  API ([`95234d1`][rr-95234d1]).
+
+### Other
+
+- CI and `just ok` build with `--all-targets` so examples are exercised
+  alongside the library crates.
+
+[rr-212]: https://github.com/raylib-rs/raylib-rs/pull/212
+[rr-247]: https://github.com/raylib-rs/raylib-rs/issues/247
+[rr-250]: https://github.com/raylib-rs/raylib-rs/pull/250
+[rr-257]: https://github.com/raylib-rs/raylib-rs/pull/257
+[rr-4d53bd4]: https://github.com/raylib-rs/raylib-rs/commit/4d53bd49af9a437433b7dff92b38cb06831351df
+[rr-95234d1]: https://github.com/raylib-rs/raylib-rs/commit/95234d17a1943e00b06e30f8323a63b78323880c
+[rr-aadf1a7]: https://github.com/raylib-rs/raylib-rs/commit/aadf1a76be022f197460d061c17570803010df58
+[rr-cb0c004]: https://github.com/raylib-rs/raylib-rs/commit/cb0c0048b6c80ec8e487fafad2b07da1886007c8
+[rr-ccc0827]: https://github.com/raylib-rs/raylib-rs/commit/ccc0827b9667578476c67b6c9d3b37a1b167034e
+[rr-e2be94b]: https://github.com/raylib-rs/raylib-rs/commit/e2be94bab26db3a30bca7226e5f03a4b15c54b0e
+
 ## 5.5.2
 
 - Renamed to sola-raylib and sola-raylib-sys
@@ -23,130 +79,101 @@ Incomplete changelog below from raylib-rs. Keeping around for posterity's sake.
 - [core] ADDED: BeginVrStereoMode()
 - [core] ADDED: EndVrStereoMode()
 
-- [core] ADDED: GetCurrentMonitor() (#1485) by @object71
-  [core] ADDED: SetGamepadMappings() (#1506)
+- [core] ADDED: GetCurrentMonitor() (#1485) by @object71 [core] ADDED:
+  SetGamepadMappings() (#1506)
 - [core] RENAMED: struct Camera: camera.type to camera.projection
 - [core] RENAMED: LoadShaderCode() to LoadShaderFromMemory() (#1690)
 - [core] RENAMED: SetMatrixProjection() to rlSetMatrixProjection()
 - [core] RENAMED: SetMatrixModelview() to rlSetMatrixModelview()
 - [core] RENAMED: GetMatrixModelview() to rlGetMatrixModelview()
 - [core] RENAMED: GetMatrixProjection() to rlGetMatrixProjection()
-- [core] RENAMED: GetShaderDefault() to rlGetShaderDefault()
-  [core] RENAMED: GetTextureDefault() to rlGetTextureDefault()
-  [core] REMOVED: GetShapesTexture()
-  [core] REMOVED: GetShapesTextureRec()
-  [core] REMOVED: GetMouseCursor()
-- [core] REMOVED: SetTraceLogExit()
-  [core] REVIEWED: GetFileName() and GetDirectoryPath() (#1534) by @gilzoide
-  [core] REVIEWED: Wait() to support FreeBSD (#1618)
-  [core] REVIEWED: HighDPI support on macOS retina (#1510)
-  [core] REDESIGNED: GetFileExtension(), includes the .dot
-  [core] REDESIGNED: IsFileExtension(), includes the .dot
-  [core] REDESIGNED: Compresion API to use sdefl/sinfl libs
-- [rlgl] ADDED: SUPPORT_GL_DETAILS_INFO config flag
-  [rlgl] REMOVED: GenTexture\*() functions (#721)
-  [rlgl] REVIEWED: rlLoadShaderDefault()
-  [rlgl] REDESIGNED: rlLoadExtensions(), more details exposed
-  [raymath] REVIEWED: QuaternionFromEuler() (#1651)
-  [raymath] REVIEWED: MatrixRotateZYX() (#1642)
-- [shapes] ADDED: DrawLineBezierQuad() (#1468) by @epsilon-phase
-  [shapes] ADDED: CheckCollisionLines()
-- [shapes] ADDED: CheckCollisionPointLine() by @mkupiec1
-  [shapes] REVIEWED: CheckCollisionPointTriangle() by @mkupiec1
-  [shapes] REDESIGNED: SetShapesTexture()
+- [core] RENAMED: GetShaderDefault() to rlGetShaderDefault() [core] RENAMED:
+  GetTextureDefault() to rlGetTextureDefault() [core] REMOVED:
+  GetShapesTexture() [core] REMOVED: GetShapesTextureRec() [core] REMOVED:
+  GetMouseCursor()
+- [core] REMOVED: SetTraceLogExit() [core] REVIEWED: GetFileName() and
+  GetDirectoryPath() (#1534) by @gilzoide [core] REVIEWED: Wait() to support
+  FreeBSD (#1618) [core] REVIEWED: HighDPI support on macOS retina (#1510)
+  [core] REDESIGNED: GetFileExtension(), includes the .dot [core] REDESIGNED:
+  IsFileExtension(), includes the .dot [core] REDESIGNED: Compresion API to use
+  sdefl/sinfl libs
+- [rlgl] ADDED: SUPPORT_GL_DETAILS_INFO config flag [rlgl] REMOVED:
+  GenTexture\*() functions (#721) [rlgl] REVIEWED: rlLoadShaderDefault() [rlgl]
+  REDESIGNED: rlLoadExtensions(), more details exposed [raymath] REVIEWED:
+  QuaternionFromEuler() (#1651) [raymath] REVIEWED: MatrixRotateZYX() (#1642)
+- [shapes] ADDED: DrawLineBezierQuad() (#1468) by @epsilon-phase [shapes] ADDED:
+  CheckCollisionLines()
+- [shapes] ADDED: CheckCollisionPointLine() by @mkupiec1 [shapes] REVIEWED:
+  CheckCollisionPointTriangle() by @mkupiec1 [shapes] REDESIGNED:
+  SetShapesTexture()
 - [shapes] REDESIGNED: DrawCircleSector(), to use float params
 - [shapes] REDESIGNED: DrawCircleSectorLines(), to use float params
 - [shapes] REDESIGNED: DrawRing(), to use float params
 - [shapes] REDESIGNED: DrawRingLines(), to use float params
 - [textures] ADDED: DrawTexturePoly() and example (#1677) by @chriscamacho
-- [textures] ADDED: UnloadImageColors() for allocs consistency
-  [textures] RENAMED: GetImageData() to LoadImageColors()
-  [textures] REVIEWED: ImageClearBackground() and ImageDrawRectangleRec() (#1487) by @JeffM2501
-  [textures] REVIEWED: DrawTexturePro() and DrawRectanglePro() transformations (#1632) by @ChrisDill
-  [text] REDESIGNED: DrawFPS()
-- [models] ADDED: UploadMesh() (#1529)
-  [models] ADDED: UpdateMeshBuffer()
-  [models] ADDED: DrawMesh()
-  [models] ADDED: DrawMeshInstanced()
-  [models] ADDED: UnloadModelAnimations() (#1648) by @object71
-  :( [models] REMOVED: DrawGizmo()
-- [models] REMOVED: LoadMeshes()
-  [models] REMOVED: MeshNormalsSmooth()
-- [models] REVIEWED: DrawLine3D() (#1643)
-  [audio] REVIEWED: Multichannel sound system (#1548)
-  [audio] REVIEWED: jar_xm library (#1701) by @jmorel33
-  [utils] ADDED: SetLoadFileDataCallback()
-  [utils] ADDED: SetSaveFileDataCallback()
-  [utils] ADDED: SetLoadFileTextCallback()
-  [utils] ADDED: SetSaveFileTextCallback()
-  [examples] ADDED: text_draw_3d (#1689) by @Demizdor
-  [examples] ADDED: textures_poly (#1677) by @chriscamacho
-  [examples] ADDED: models_gltf_model (#1551) by @object71
-  [examples] RENAMED: shaders_rlgl_mesh_instanced to shaders_mesh_intancing
-  [examples] REDESIGNED: shaders_rlgl_mesh_instanced by @moliad
-  [examples] REDESIGNED: core_vr_simulator
-  [examples] REDESIGNED: models_yaw_pitch_roll
-  [build] ADDED: Config flag: SUPPORT_STANDARD_FILEIO
-  [build] ADDED: Config flag: SUPPORT_WINMM_HIGHRES_TIMER (#1641)
-  [build] ADDED: Config flag: SUPPORT_GL_DETAILS_INFO
-  [build] ADDED: Examples projects to VS2019 solution
-  [build] REVIEWED: Makefile to support PLATFORM_RPI (#1580)
-  [build] REVIEWED: Multiple typecast warnings by @JeffM2501
-  [build] REDESIGNED: VS2019 project build paths
-  [build] REDESIGNED: CMake build system by @object71
-  [*] RENAMED: Several functions parameters for consistency
-  [*] UPDATED: Multiple bindings to latest version
-  [*] UPDATED: All external libraries to latest versions
-  [*] Multiple code improvements and fixes by multiple contributors!
+- [textures] ADDED: UnloadImageColors() for allocs consistency [textures]
+  RENAMED: GetImageData() to LoadImageColors() [textures] REVIEWED:
+  ImageClearBackground() and ImageDrawRectangleRec() (#1487) by @JeffM2501
+  [textures] REVIEWED: DrawTexturePro() and DrawRectanglePro() transformations
+  (#1632) by @ChrisDill [text] REDESIGNED: DrawFPS()
+- [models] ADDED: UploadMesh() (#1529) [models] ADDED: UpdateMeshBuffer()
+  [models] ADDED: DrawMesh() [models] ADDED: DrawMeshInstanced() [models] ADDED:
+  UnloadModelAnimations() (#1648) by @object71 :( [models] REMOVED: DrawGizmo()
+- [models] REMOVED: LoadMeshes() [models] REMOVED: MeshNormalsSmooth()
+- [models] REVIEWED: DrawLine3D() (#1643) [audio] REVIEWED: Multichannel sound
+  system (#1548) [audio] REVIEWED: jar_xm library (#1701) by @jmorel33 [utils]
+  ADDED: SetLoadFileDataCallback() [utils] ADDED: SetSaveFileDataCallback()
+  [utils] ADDED: SetLoadFileTextCallback() [utils] ADDED:
+  SetSaveFileTextCallback() [examples] ADDED: text_draw_3d (#1689) by @Demizdor
+  [examples] ADDED: textures_poly (#1677) by @chriscamacho [examples] ADDED:
+  models_gltf_model (#1551) by @object71 [examples] RENAMED:
+  shaders_rlgl_mesh_instanced to shaders_mesh_intancing [examples] REDESIGNED:
+  shaders_rlgl_mesh_instanced by @moliad [examples] REDESIGNED:
+  core_vr_simulator [examples] REDESIGNED: models_yaw_pitch_roll [build] ADDED:
+  Config flag: SUPPORT_STANDARD_FILEIO [build] ADDED: Config flag:
+  SUPPORT_WINMM_HIGHRES_TIMER (#1641) [build] ADDED: Config flag:
+  SUPPORT_GL_DETAILS_INFO [build] ADDED: Examples projects to VS2019 solution
+  [build] REVIEWED: Makefile to support PLATFORM_RPI (#1580) [build] REVIEWED:
+  Multiple typecast warnings by @JeffM2501 [build] REDESIGNED: VS2019 project
+  build paths [build] REDESIGNED: CMake build system by @object71 [_] RENAMED:
+  Several functions parameters for consistency [_] UPDATED: Multiple bindings to
+  latest version [_] UPDATED: All external libraries to latest versions [_]
+  Multiple code improvements and fixes by multiple contributors!
 
 ## 3.5.0 (Done)
 
-Added: SetWindowState
-Added: ClearW‌indowState
-Added: IsWindowFocused
-Added: GetWindowScaleDPI
-Added: GetMonitorRefreshRate
-Added: IsCursorOnScreen
-Added: SetMouseCursor/GetMouseCursor
-Added: Normalize
-Added: Remap
-Added: Vector2Reflect
-Added: Vector2LengthSqr
-Added: Vector2MoveTowards
-Added: UnloadFontData
-Added: LoadFontFromMemmory(ttf)
-Added: ColorAlphaBlend
-Added: GetPixelColor
-Added: SetPixelColor
-Added: LoadImageFromMemory
-Added: LoadImageAnim
-Added: DrawTextureTiled
-Added: UpdateTextureRec
-Added: UnloadImageColors,
-Added: UnloadImagePallet,
-Added: UnloadWaveSample
-Added: DrawTriangle3D
-Added: DrawTriangleStrip3D
-Added: LoadWaveFromMemory
-Added: MemAlloc() / MemFree()
-Added: UnloadFileData
-Added: UnloadFileText
+Added: SetWindowState Added: ClearW‌indowState Added: IsWindowFocused Added:
+GetWindowScaleDPI Added: GetMonitorRefreshRate Added: IsCursorOnScreen Added:
+SetMouseCursor/GetMouseCursor Added: Normalize Added: Remap Added:
+Vector2Reflect Added: Vector2LengthSqr Added: Vector2MoveTowards Added:
+UnloadFontData Added: LoadFontFromMemmory(ttf) Added: ColorAlphaBlend Added:
+GetPixelColor Added: SetPixelColor Added: LoadImageFromMemory Added:
+LoadImageAnim Added: DrawTextureTiled Added: UpdateTextureRec Added:
+UnloadImageColors, Added: UnloadImagePallet, Added: UnloadWaveSample Added:
+DrawTriangle3D Added: DrawTriangleStrip3D Added: LoadWaveFromMemory Added:
+MemAlloc() / MemFree() Added: UnloadFileData Added: UnloadFileText
 
 ## 0.10.0 (WIP)
 
 - Basic macOS support. Currently untested.
 - Improved ergonomics across the board:
-  - Copied over and tweaked many FFI structs so that fields use proper types instead of FFI types.
-  - Added `vec2`, `vec3`, `quat`, `rgb`, and `rgba` convenience functions for a middle ground between `From` conversion and `new` methods.
-  - Changed several key and gamepad functions to use `u32`, making it more ergonomic with key/gamepad constants.
-  - Added optional `prelude` module for conveniently bringing in all the common types and definitions.
+  - Copied over and tweaked many FFI structs so that fields use proper types
+    instead of FFI types.
+  - Added `vec2`, `vec3`, `quat`, `rgb`, and `rgba` convenience functions for a
+    middle ground between `From` conversion and `new` methods.
+  - Changed several key and gamepad functions to use `u32`, making it more
+    ergonomic with key/gamepad constants.
+  - Added optional `prelude` module for conveniently bringing in all the common
+    types and definitions.
 - Fixed unnecessary `&mut` in `load_image_ex` and `draw_poly_ex`.
 - Fixed linking on MSVC toolchains by including `user32`.
-- Prevent `RaylibHandle` from being manually constructed. Fixes a safety soundness hole.
+- Prevent `RaylibHandle` from being manually constructed. Fixes a safety
+  soundness hole.
 
 ## 0.9.1
 
-- Fixed docs.rs build by removing use of a uniform module path. This also keeps the crate compatible with Rust 1.31+.
+- Fixed docs.rs build by removing use of a uniform module path. This also keeps
+  the crate compatible with Rust 1.31+.
 
 ## 0.9.0
 

--- a/examples/rgui.rs
+++ b/examples/rgui.rs
@@ -22,6 +22,7 @@ pub fn main() {
     let (mut rl, thread) = raylib::init()
         .width(screen_width)
         .height(screen_height)
+        .highdpi()
         .title("raygui - controls test suite")
         .build();
 

--- a/justfile
+++ b/justfile
@@ -10,7 +10,7 @@ ok: fmt-check build clippy test examples
 
 # Build every crate in the workspace.
 build:
-    cargo build --workspace
+    cargo build --workspace --all-targets
 
 # Lint every crate and target. Warnings are allowed for now (lots of pre-existing upstream noise).
 clippy:
@@ -31,7 +31,7 @@ fmt-check:
 
 # Build the examples binaries crate.
 examples:
-    cd examples && cargo build
+    cd examples && cargo build --all-targets
 
 # Run a specific example by name, e.g. `just sample drop`.
 example name:

--- a/raylib/src/core/audio.rs
+++ b/raylib/src/core/audio.rs
@@ -552,7 +552,7 @@ impl<'aud> AudioStream<'aud> {
             ffi::UpdateAudioStream(
                 self.0,
                 data.as_ptr() as *const std::os::raw::c_void,
-                std::mem::size_of_val(data) as i32,
+                data.len() as i32,
             );
         }
     }

--- a/raylib/src/core/audio.rs
+++ b/raylib/src/core/audio.rs
@@ -624,8 +624,8 @@ impl<'aud> AudioStream<'aud> {
     }
 }
 
-impl<'bind> Sound<'_> {
-    pub fn alias<'snd>(&'snd self) -> Result<SoundAlias<'bind, 'snd>, Error> {
+impl<'bind> Sound<'bind> {
+    pub fn alias<'snd>(&'snd self) -> Result<SoundAlias<'snd, 'bind>, Error> {
         let s = unsafe { ffi::LoadSoundAlias(self.0) };
         if s.stream.buffer.is_null() {
             return Err(error!("failed to load sound from wave"));

--- a/raylib/src/core/drawing.rs
+++ b/raylib/src/core/drawing.rs
@@ -36,9 +36,10 @@ impl RaylibHandle {
             ffi::BeginDrawing();
         };
         func(RaylibDrawHandle(self));
-        unsafe {
-            ffi::EndDrawing();
-        };
+        // Uncomment the following if RaylibDrawHandle has been changed to no longer call EndDrawing() in its drop implementation:
+        // unsafe {
+        //     ffi::EndDrawing();
+        // }
     }
 }
 
@@ -127,6 +128,8 @@ where
     ) {
         unsafe { ffi::BeginTextureMode(*framebuffer) }
         func(RaylibTextureMode(self, framebuffer));
+        // Uncomment the following if RaylibTextureMode has been changed to no longer call EndTextureMode() in its drop implementation:
+        // unsafe { ffi::EndTextureMode(); }
     }
 }
 
@@ -174,6 +177,8 @@ where
     ) {
         unsafe { ffi::BeginVrStereoMode(*vr_config.as_ref()) }
         func(RaylibVRMode(self, vr_config));
+        // Uncomment the following if RaylibVRMode has been changed to no longer call EndTextureMode() in its drop implementation:
+        // unsafe { ffi::EndVrStereoMode(); }
     }
 }
 
@@ -226,9 +231,10 @@ where
             ffi::BeginMode2D(camera.into());
         }
         func(RaylibMode2D(self), camera);
-        unsafe {
-            ffi::EndMode2D();
-        }
+        // Uncomment the following if RaylibMode2D has been changed to no longer call EndMode2D() in its drop implementation:
+        // unsafe {
+        //     ffi::EndMode2D();
+        // }
     }
 }
 
@@ -281,9 +287,10 @@ where
             ffi::BeginMode3D(camera.into());
         }
         func(RaylibMode3D(self), camera);
-        unsafe {
-            ffi::EndMode3D();
-        }
+        // Uncomment the following if RaylibMode3D has been changed to no longer call EndMode3D() in its drop implementation:
+        // unsafe {
+        //     ffi::EndMode3D();
+        // }
     }
 }
 
@@ -332,6 +339,8 @@ where
     ) {
         unsafe { ffi::BeginShaderMode(*shader.as_ref()) }
         func(RaylibShaderMode(self, shader));
+        // Uncomment the following if RaylibShaderMode has been changed to no longer call EndShaderMode() in its drop implementation:
+        // unsafe { ffi::EndShaderMode(); }
     }
 }
 
@@ -382,6 +391,8 @@ where
     ) {
         unsafe { ffi::BeginBlendMode((blend_mode as u32) as i32) }
         func(RaylibBlendMode(self));
+        // Uncomment the following if RaylibBlendMode has been changed to no longer call EndBlendMode() in its drop implementation:
+        // unsafe { ffi::EndBlendMode(); }
     }
 }
 
@@ -438,6 +449,8 @@ where
     ) {
         unsafe { ffi::BeginScissorMode(x, y, width, height) }
         func(RaylibScissorMode(self));
+        // Uncomment the following if RaylibScissorMode has been changed to no longer call EndScissorMode() in its drop implementation:
+        // unsafe { ffi::EndScissorMode(); }
     }
 }
 

--- a/raylib/src/core/models.rs
+++ b/raylib/src/core/models.rs
@@ -347,15 +347,29 @@ pub trait RaylibMesh: AsRef<ffi::Mesh> + AsMut<ffi::Mesh> {
             },
         )
     }
-    fn indicies(&self) -> &[u16] {
+    fn indices(&self) -> &[u16] {
         NonNull::new(self.as_ref().indices).map_or(&[], |data| unsafe {
             NonNull::slice_from_raw_parts(data, self.as_ref().triangleCount as usize * 3).as_ref()
         })
     }
-    fn indicies_mut(&mut self) -> &mut [u16] {
+    fn indices_mut(&mut self) -> &mut [u16] {
         NonNull::new(self.as_ref().indices).map_or(&mut [], |data| unsafe {
             NonNull::slice_from_raw_parts(data, self.as_ref().triangleCount as usize * 3).as_mut()
         })
+    }
+    #[deprecated(
+        since = "5.5.3",
+        note = "use `indices` instead; will be removed in 6.0"
+    )]
+    fn indicies(&self) -> &[u16] {
+        self.indices()
+    }
+    #[deprecated(
+        since = "5.5.3",
+        note = "use `indices_mut` instead; will be removed in 6.0"
+    )]
+    fn indicies_mut(&mut self) -> &mut [u16] {
+        self.indices_mut()
     }
 
     /// Generate polygonal mesh

--- a/raylib/src/core/models.rs
+++ b/raylib/src/core/models.rs
@@ -7,6 +7,7 @@ use crate::error::{error, Error};
 use crate::{consts, ffi};
 use std::ffi::CString;
 use std::os::raw::c_void;
+use std::ptr::NonNull;
 
 fn no_drop<T>(_thing: T) {}
 make_thin_wrapper!(Model, ffi::Model, ffi::UnloadModel);
@@ -304,84 +305,57 @@ pub trait RaylibMesh: AsRef<ffi::Mesh> + AsMut<ffi::Mesh> {
         );
     }
     fn vertices(&self) -> &[Vector3] {
-        unsafe {
-            std::slice::from_raw_parts(
-                self.as_ref().vertices as *const Vector3,
-                self.as_ref().vertexCount as usize,
-            )
-        }
+        NonNull::new(self.as_ref().vertices.cast()).map_or(&[], |data| unsafe {
+            NonNull::slice_from_raw_parts(data, self.as_ref().vertexCount as usize).as_ref()
+        })
     }
     fn vertices_mut(&mut self) -> &mut [Vector3] {
-        unsafe {
-            std::slice::from_raw_parts_mut(
-                self.as_mut().vertices as *mut Vector3,
-                self.as_mut().vertexCount as usize,
-            )
-        }
+        NonNull::new(self.as_ref().vertices.cast()).map_or(&mut [], |data| unsafe {
+            NonNull::slice_from_raw_parts(data, self.as_ref().vertexCount as usize).as_mut()
+        })
     }
     fn normals(&self) -> &[Vector3] {
-        unsafe {
-            std::slice::from_raw_parts(
-                self.as_ref().normals as *const Vector3,
-                self.as_ref().vertexCount as usize,
-            )
-        }
+        NonNull::new(self.as_ref().normals.cast()).map_or(&[], |data| unsafe {
+            NonNull::slice_from_raw_parts(data, self.as_ref().vertexCount as usize).as_ref()
+        })
     }
     fn normals_mut(&mut self) -> &mut [Vector3] {
-        unsafe {
-            std::slice::from_raw_parts_mut(
-                self.as_mut().normals as *mut Vector3,
-                self.as_mut().vertexCount as usize,
-            )
-        }
+        NonNull::new(self.as_ref().normals.cast()).map_or(&mut [], |data| unsafe {
+            NonNull::slice_from_raw_parts(data, self.as_ref().vertexCount as usize).as_mut()
+        })
     }
     fn tangents(&self) -> &[Vector3] {
-        unsafe {
-            std::slice::from_raw_parts(
-                self.as_ref().tangents as *const Vector3,
-                self.as_ref().vertexCount as usize,
-            )
-        }
+        NonNull::new(self.as_ref().tangents.cast()).map_or(&[], |data| unsafe {
+            NonNull::slice_from_raw_parts(data, self.as_ref().vertexCount as usize).as_ref()
+        })
     }
     fn tangents_mut(&mut self) -> &mut [Vector3] {
-        unsafe {
-            std::slice::from_raw_parts_mut(
-                self.as_mut().tangents as *mut Vector3,
-                self.as_mut().vertexCount as usize,
-            )
-        }
+        NonNull::new(self.as_ref().tangents.cast()).map_or(&mut [], |data| unsafe {
+            NonNull::slice_from_raw_parts(data, self.as_ref().vertexCount as usize).as_mut()
+        })
     }
     fn colors(&self) -> &[crate::color::Color] {
-        unsafe {
-            std::slice::from_raw_parts(
-                self.as_ref().colors as *const crate::color::Color,
-                self.as_ref().vertexCount as usize,
-            )
-        }
+        NonNull::new(self.as_ref().colors as *mut crate::color::Color).map_or(&[], |data| unsafe {
+            NonNull::slice_from_raw_parts(data, self.as_ref().vertexCount as usize).as_ref()
+        })
     }
     fn colors_mut(&mut self) -> &mut [crate::color::Color] {
-        unsafe {
-            std::slice::from_raw_parts_mut(
-                self.as_mut().colors as *mut crate::color::Color,
-                self.as_mut().vertexCount as usize,
-            )
-        }
+        NonNull::new(self.as_ref().colors as *mut crate::color::Color).map_or(
+            &mut [],
+            |data| unsafe {
+                NonNull::slice_from_raw_parts(data, self.as_ref().vertexCount as usize).as_mut()
+            },
+        )
     }
     fn indicies(&self) -> &[u16] {
-        unsafe {
-            std::slice::from_raw_parts(
-                self.as_ref().indices as *const u16,
-                self.as_ref().vertexCount as usize,
-            )
-        }
+        NonNull::new(self.as_ref().indices).map_or(&[], |data| unsafe {
+            NonNull::slice_from_raw_parts(data, self.as_ref().vertexCount as usize).as_ref()
+        })
     }
     fn indicies_mut(&mut self) -> &mut [u16] {
-        unsafe {
-            std::slice::from_raw_parts_mut(
-                self.as_mut().indices,
-                self.as_mut().vertexCount as usize,
-            )
-        }
+        NonNull::new(self.as_ref().indices).map_or(&mut [], |data| unsafe {
+            NonNull::slice_from_raw_parts(data, self.as_ref().vertexCount as usize).as_mut()
+        })
     }
 
     /// Generate polygonal mesh

--- a/raylib/src/core/models.rs
+++ b/raylib/src/core/models.rs
@@ -99,7 +99,7 @@ impl RaylibHandle {
             }
         }
         unsafe {
-            ffi::UnloadModelAnimations(m_ptr, m_size);
+            ffi::MemFree(m_ptr as *mut ::std::os::raw::c_void);
         }
         Ok(m_vec)
     }

--- a/raylib/src/core/models.rs
+++ b/raylib/src/core/models.rs
@@ -349,12 +349,12 @@ pub trait RaylibMesh: AsRef<ffi::Mesh> + AsMut<ffi::Mesh> {
     }
     fn indicies(&self) -> &[u16] {
         NonNull::new(self.as_ref().indices).map_or(&[], |data| unsafe {
-            NonNull::slice_from_raw_parts(data, self.as_ref().vertexCount as usize).as_ref()
+            NonNull::slice_from_raw_parts(data, self.as_ref().triangleCount as usize * 3).as_ref()
         })
     }
     fn indicies_mut(&mut self) -> &mut [u16] {
         NonNull::new(self.as_ref().indices).map_or(&mut [], |data| unsafe {
-            NonNull::slice_from_raw_parts(data, self.as_ref().vertexCount as usize).as_mut()
+            NonNull::slice_from_raw_parts(data, self.as_ref().triangleCount as usize * 3).as_mut()
         })
     }
 

--- a/raylib/src/core/texture.rs
+++ b/raylib/src/core/texture.rs
@@ -1109,10 +1109,23 @@ pub trait RaylibTexture2D: AsRef<ffi::Texture2D> + AsMut<ffi::Texture2D> {
         rec: impl Into<ffi::Rectangle>,
         pixels: &[u8],
     ) -> Result<(), Error> {
+        let rec = rec.into();
+        
+        if (rec.x < 0.0) || (rec.y < 0.0) || ((rec.x as i32 + rec.width as i32) > (self.as_ref().width)) || ((rec.y as i32 + rec.height as i32) > (self.as_ref().height)) {
+            return Err(error!(
+                "update_texture: Destination rectangle cannot exceed texture bounds."
+            ));
+        }
+        if (rec.width < 0.0) || (rec.height < 0.0) {
+            return Err(error!(
+                "update_texture: Destination rectangle cannot have negative extents."
+            ));
+        }
+        
         let expected_len = unsafe {
             get_pixel_data_size(
-                self.as_ref().width,
-                self.as_ref().height,
+                rec.width as i32,
+                rec.height as i32,
                 std::mem::transmute::<i32, ffi::PixelFormat>(self.as_ref().format),
             ) as usize
         };
@@ -1126,7 +1139,7 @@ pub trait RaylibTexture2D: AsRef<ffi::Texture2D> + AsMut<ffi::Texture2D> {
         unsafe {
             ffi::UpdateTextureRec(
                 *self.as_ref(),
-                rec.into(),
+                rec,
                 pixels.as_ptr() as *const std::os::raw::c_void,
             )
         }

--- a/raylib/src/core/texture.rs
+++ b/raylib/src/core/texture.rs
@@ -755,7 +755,7 @@ impl Image {
     }
 
     /// Export image to memory buffer.
-    pub fn export_image_to_memory(&self, file_type: &str) -> Result<&[u8], Error> {
+    pub fn export_image_to_memory(&self, file_type: &str) -> Result<Vec<u8>, Error> {
         if self.width == 0 {
             return Err(error!("Invalid image; width == 0"));
         }
@@ -767,15 +767,18 @@ impl Image {
         }
 
         let c_filetype = CString::new(file_type).unwrap();
-        let data_size: &mut i32 = &mut 0;
-        let data = unsafe { ffi::ExportImageToMemory(self.0, c_filetype.as_ptr(), data_size) };
+        let mut data_size: i32 = 0;
+        let data = unsafe { ffi::ExportImageToMemory(self.0, c_filetype.as_ptr(), &mut data_size) };
 
         // The actual function returns null if the code for converting to a file type never goes off.
         if data.is_null() {
             return Err(error!("Unsupported format."));
         }
 
-        Ok(unsafe { std::slice::from_raw_parts(data as *const u8, *data_size as usize) })
+        let out =
+            unsafe { std::slice::from_raw_parts(data as *const u8, data_size as usize) }.to_vec();
+        unsafe { ffi::MemFree(data as *mut std::os::raw::c_void) };
+        Ok(out)
     }
 
     /// Apply custom square convolution kernel to image

--- a/raylib/src/core/texture.rs
+++ b/raylib/src/core/texture.rs
@@ -1110,8 +1110,12 @@ pub trait RaylibTexture2D: AsRef<ffi::Texture2D> + AsMut<ffi::Texture2D> {
         pixels: &[u8],
     ) -> Result<(), Error> {
         let rec = rec.into();
-        
-        if (rec.x < 0.0) || (rec.y < 0.0) || ((rec.x as i32 + rec.width as i32) > (self.as_ref().width)) || ((rec.y as i32 + rec.height as i32) > (self.as_ref().height)) {
+
+        if (rec.x < 0.0)
+            || (rec.y < 0.0)
+            || ((rec.x as i32 + rec.width as i32) > (self.as_ref().width))
+            || ((rec.y as i32 + rec.height as i32) > (self.as_ref().height))
+        {
             return Err(error!(
                 "update_texture: Destination rectangle cannot exceed texture bounds."
             ));
@@ -1121,7 +1125,7 @@ pub trait RaylibTexture2D: AsRef<ffi::Texture2D> + AsMut<ffi::Texture2D> {
                 "update_texture: Destination rectangle cannot have negative extents."
             ));
         }
-        
+
         let expected_len = unsafe {
             get_pixel_data_size(
                 rec.width as i32,

--- a/raylib/src/rgui/safe.rs
+++ b/raylib/src/rgui/safe.rs
@@ -218,8 +218,14 @@ pub trait RaylibDrawGui {
     /// Panel control, useful to group controls
     #[inline]
     fn gui_panel(&mut self, bounds: impl Into<ffi::Rectangle>, text: &str) -> bool {
-        let c_filename = CString::new(text).unwrap();
-        unsafe { ffi::GuiPanel(bounds.into(), c_filename.as_ptr()) > 0 }
+        let cstr: CString;
+        let c_text = if text.is_empty() {
+            std::ptr::null()
+        } else {
+            cstr = CString::new(text).unwrap();
+            cstr.as_ptr()
+        };
+        unsafe { ffi::GuiPanel(bounds.into(), c_text) > 0 }
     }
     /// Scroll Panel control
     #[inline]

--- a/raylib/src/rgui/safe.rs
+++ b/raylib/src/rgui/safe.rs
@@ -5,7 +5,7 @@ use crate::core::text::WeakFont;
 use crate::core::RaylibHandle;
 use crate::ffi;
 
-use std::ffi::{CStr, CString, c_char};
+use std::ffi::{c_char, CStr, CString};
 
 /// Global gui modification functions
 impl RaylibHandle {

--- a/raylib/src/rgui/safe.rs
+++ b/raylib/src/rgui/safe.rs
@@ -5,7 +5,7 @@ use crate::core::text::WeakFont;
 use crate::core::RaylibHandle;
 use crate::ffi;
 
-use std::ffi::{c_char, CStr, CString};
+use std::ffi::{CStr, CString, c_char};
 
 /// Global gui modification functions
 impl RaylibHandle {
@@ -381,15 +381,32 @@ pub trait RaylibDrawGui {
         buffer: &mut String,
         edit_mode: bool,
     ) -> bool {
-        let len = buffer.len();
-        unsafe {
-            ffi::GuiTextBox(
-                bounds.into(),
-                buffer.as_mut_ptr() as *mut _,
-                len as i32,
-                edit_mode,
-            ) > 0
+        // NOTE: method of dealing with null terminated strings copied from imgui(input_widget.rs:289, build func)
+        buffer.push('\0');
+        let (ptr, capacity) = (buffer.as_mut_ptr(), buffer.capacity());
+        let res = unsafe {
+            ffi::GuiTextBox(bounds.into(), ptr as *mut i8, capacity as i32, edit_mode) > 0
+        };
+        let cap = buffer.capacity();
+
+        // SAFETY: this slice is simply a view into the underlying buffer
+        // of a String. We MAY be holding onto a view of uninitialized memory,
+        // however, since we're holding this as a u8 slice, I think it should be
+        // alright...
+        // additionally, we can go over the bytes directly, rather than char indices,
+        // because NUL will never appear in any UTF8 outside the NUL character (ie, within
+        // a char).
+        let buf = unsafe { std::slice::from_raw_parts(buffer.as_ptr(), cap) };
+        if let Some(len) = buf.iter().position(|x| *x == b'\0') {
+            // `len` is the position of the first `\0` byte in the String
+            unsafe {
+                buffer.as_mut_vec().set_len(len);
+            }
+        } else {
+            // There is no null terminator, the best we can do is to not
+            // update the string length.
         }
+        res
     }
 
     /// Slider control, returns selected value
@@ -572,22 +589,45 @@ pub trait RaylibDrawGui {
         text_max_size: i32,
         secret_view_active: &mut bool,
     ) -> i32 {
-        // rgui.h: line 3699 MAX_FILENAME_LEN
-        text.reserve(256usize.saturating_sub(text.len()));
+        text.reserve(text_max_size as usize);
+        // NOTE: method of dealing with null terminated strings copied from imgui(input_widget.rs:289, build func)
+        text.push('\0');
+        let (ptr, capacity) = (text.as_mut_ptr(), text.capacity());
+
         let c_title = CString::new(title).unwrap();
         let c_message = CString::new(message).unwrap();
         let c_buttons = CString::new(buttons).unwrap();
-        unsafe {
+        let btn_index = unsafe {
             ffi::GuiTextInputBox(
                 bounds.into(),
                 c_title.as_ptr(),
                 c_message.as_ptr(),
                 c_buttons.as_ptr(),
-                text.as_mut_ptr() as *mut _,
-                text_max_size,
+                ptr as *mut i8,
+                capacity as i32,
                 secret_view_active,
             )
+        };
+        let cap = text.capacity();
+
+        // SAFETY: this slice is simply a view into the underlying buffer
+        // of a String. We MAY be holding onto a view of uninitialized memory,
+        // however, since we're holding this as a u8 slice, I think it should be
+        // alright...
+        // additionally, we can go over the bytes directly, rather than char indices,
+        // because NUL will never appear in any UTF8 outside the NUL character (ie, within
+        // a char).
+        let buf = unsafe { std::slice::from_raw_parts(text.as_ptr(), cap) };
+        if let Some(len) = buf.iter().position(|x| *x == b'\0') {
+            // `len` is the position of the first `\0` byte in the String
+            unsafe {
+                text.as_mut_vec().set_len(len);
+            }
+        } else {
+            // There is no null terminator, the best we can do is to not
+            // update the string length.
         }
+        btn_index
     }
 
     /// Color Picker control


### PR DESCRIPTION
This PR cherrypicks over the most important fixes from raylib-rs without changing the Raylib C commit SHA.

See commits for details. Maintains original authorship attribution.

Helpful to get these changes in before starting on the 6.0 upgrade. Also benefits people sticking with the 5.5 series.
