### PR TITLE
chore(examples): highdpi + `just examples`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ soundness and correctness. Thanks to all the original authors linked below.
 
 - CI and `just ok` build with `--all-targets` so examples are exercised
   alongside the library crates.
+- Examples look better on High DPI screens.
+- `just examples` to quickly run a bunch of different examples.
 
 [rr-212]: https://github.com/raylib-rs/raylib-rs/pull/212
 [rr-247]: https://github.com/raylib-rs/raylib-rs/issues/247

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -11,9 +11,13 @@ Run `just setup` to initialize the needed Git submodules.
 
 ## Verifying Your Changes
 
-The best way to verify your changes is to add a project to ./examples that exercises the changed code. Then add that to `just examples` in the `justfile`. That way it can be verified to not break with future changes.
+The best way to verify your changes is to add a project to ./examples that
+exercises the changed code. Then add that to `just examples` in the `justfile`.
+That way it can be verified to not break with future changes.
 
-If you want to verify your changes haven't broken other code and examples, run `just examples` to quickly test a bunch of different functionality in sola-raylib.
+If you want to verify your changes haven't broken other code and examples, run
+`just examples` to quickly test a bunch of different functionality in
+sola-raylib.
 
 Ensure `just ok` is passing before submitting changes.
 

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -9,7 +9,13 @@ on the project. See `./justfile` for available commands.
 
 Run `just setup` to initialize the needed Git submodules.
 
-`just ok` is a helpful command to run regularly and ensure is passing.
+## Verifying Your Changes
+
+The best way to verify your changes is to add a project to ./examples that exercises the changed code. Then add that to `just examples` in the `justfile`. That way it can be verified to not break with future changes.
+
+If you want to verify your changes haven't broken other code and examples, run `just examples` to quickly test a bunch of different functionality in sola-raylib.
+
+Ensure `just ok` is passing before submitting changes.
 
 ## Releasing
 

--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ changes to be more idiomatic for Rust.
   enforcing that Raylib is only initialized once, and for making sure the window
   is closed properly. RaylibHandle has no size and goes away at compile time.
   Because of mutability rules, Raylib-rs is thread safe!
-- A `RaylibHandle` and `RaylibThread` are obtained through
-  `raylib::init_window(...)` or through the newer `init()` function which will
-  allow you to `build` up some window options before initialization (replaces
-  `set_config_flags`). RaylibThread should not be sent to any other threads, or
-  used in a any syncronization primitives (Mutex, Arc) etc.
+- A `RaylibHandle` and `RaylibThread` are obtained through through the `init()`
+  function which will allow you to `build` up some window options before
+  initialization (replaces `set_config_flags`). RaylibThread should not be sent
+  to any other threads, or used in a any syncronization primitives (Mutex, Arc)
+  etc.
 - Manually closing the window is unnecessary, because `CloseWindow` is
   automatically called when `RaylibHandle` goes out of scope.
 - `Model::set_material`, `Material::set_shader`, and `MaterialMap::set_texture`

--- a/examples/3d_camera_first_person.rs
+++ b/examples/3d_camera_first_person.rs
@@ -33,7 +33,8 @@ impl Column {
 fn main() {
     let (mut rl, thread) = raylib::init()
         .size(WINDOW_WIDTH, WINDOW_HEIGHT)
-        .title("Hello, world!")
+        .title("3D Camera - First-Person")
+        .highdpi()
         .build();
 
     let mut camera = Camera3D::perspective(

--- a/examples/camera_2d.rs
+++ b/examples/camera_2d.rs
@@ -55,7 +55,7 @@ fn main() {
         // Camera rotation controls
         if rl.is_key_down(KEY_A) {
             camera.rotation -= 1.0;
-        } else if rl.is_key_down(KEY_S) {
+        } else if rl.is_key_down(KEY_D) {
             camera.rotation += 1.0;
         }
 
@@ -110,7 +110,7 @@ fn main() {
             d.draw_text("Free 2d camera controls:", 20, 20, 10, Color::BLACK);
             d.draw_text("- Right/Left to move Offset", 40, 40, 10, Color::DARKGRAY);
             d.draw_text("- Mouse Wheel to Zoom in-out", 40, 60, 10, Color::DARKGRAY);
-            d.draw_text("- A / S to Rotate", 40, 80, 10, Color::DARKGRAY);
+            d.draw_text("- A / D to Rotate", 40, 80, 10, Color::DARKGRAY);
             d.draw_text(
                 "- R to reset Zoom and Rotation",
                 40,

--- a/examples/extensions.rs
+++ b/examples/extensions.rs
@@ -6,7 +6,7 @@ mod options;
 
 trait RaylibDrawExt: RaylibDraw {
     fn custom_draw(&mut self, font: &WeakFont) {
-        self.draw_text_ex(font, "custom", rvec2(0, 0), 16.0, 0.0, Color::GREEN);
+        self.draw_text_ex(font, "custom draw", rvec2(0, 0), 16.0, 0.0, Color::GREEN);
     }
 }
 
@@ -14,7 +14,7 @@ impl<T> RaylibDrawExt for T where T: RaylibDraw {}
 
 fn main() {
     let opt = options::Opt::from_args();
-    let (mut rl, thread) = opt.open_window("Logo");
+    let (mut rl, thread) = opt.open_window("Extensions - Custom Draw");
     let font = rl.get_font_default();
     while !rl.window_should_close() {
         // Detect window close button or ESC key

--- a/examples/font.rs
+++ b/examples/font.rs
@@ -6,7 +6,11 @@ fn main() {
     let h = 450;
     let rust_orange = Color::new(222, 165, 132, 255);
     let ray_white = Color::new(255, 255, 255, 255);
-    let (mut rl, thread) = raylib::init().size(w, h).title("Logo").build();
+    let (mut rl, thread) = raylib::init()
+        .size(w, h)
+        .title("Custom Font")
+        .highdpi()
+        .build();
     rl.set_target_fps(60);
     let font = rl
         .load_font(&thread, "static/alagard.png")

--- a/examples/hello_raylib.rs
+++ b/examples/hello_raylib.rs
@@ -3,7 +3,7 @@ use raylib::prelude::*;
 fn main() {
     let (mut rl, thread) = raylib::init()
         .size(640, 480)
-        .title("Hello, World")
+        .title("Hello, Raylib")
         .highdpi()
         .build();
 

--- a/examples/options.rs
+++ b/examples/options.rs
@@ -23,6 +23,7 @@ impl Opt {
         let (mut rl, thread) = raylib::init()
             .size(self.width, self.height)
             .title(name)
+            .highdpi()
             .build();
         let logo = raylib::prelude::Image::load_image("static/logo.png").unwrap();
         rl.set_window_icon(&logo);

--- a/examples/raymarch.rs
+++ b/examples/raymarch.rs
@@ -8,7 +8,7 @@ const SHADER: &str = include_str!("static/raymarching.fs");
 
 pub fn main() {
     let opt = options::Opt::from_args();
-    let (mut rl, thread) = opt.open_window("Camera 2D");
+    let (mut rl, thread) = opt.open_window("Raymarch");
     let (w, h) = (opt.width, opt.height);
 
     let mut camera = Camera3D::perspective(

--- a/examples/yaw_pitch_roll.rs
+++ b/examples/yaw_pitch_roll.rs
@@ -63,7 +63,7 @@ fn main() {
         }
 
         // Plane yaw (y-axis) controls
-        if rl.is_key_down(raylib::consts::KeyboardKey::KEY_S) {
+        if rl.is_key_down(raylib::consts::KeyboardKey::KEY_D) {
             yaw += 1.0;
         } else if rl.is_key_down(raylib::consts::KeyboardKey::KEY_A) {
             yaw -= 1.0;
@@ -227,7 +227,7 @@ fn main() {
                 Color::DARKGRAY,
             );
             d.draw_text(
-                "Yaw controlled with: KEY_A / KEY_S",
+                "Yaw controlled with: KEY_A / KEY_D",
                 40,
                 410,
                 10,

--- a/justfile
+++ b/justfile
@@ -5,7 +5,7 @@ default:
     @just --list
 
 # Run all checks that should be green before committing/pushing.
-ok: fmt-check build clippy test examples
+ok: fmt-check build clippy test build-examples
     @echo "All checks passed."
 
 # Build every crate in the workspace.
@@ -30,7 +30,7 @@ fmt-check:
     cargo fmt --all -- --check
 
 # Build the examples binaries crate.
-examples:
+build-examples:
     cd examples && cargo build --all-targets
 
 # Run a specific example by name, e.g. `just sample drop`.
@@ -40,3 +40,20 @@ example name:
 # Initializes git submodules
 setup:
     git submodule update --init
+
+# Run a handful of examples to quickly check things are working
+examples:
+    just example 3d_camera_first_person
+    just example arkanoid
+    just example asteroids
+    just example camera_2d
+    just example extensions
+    just example hello_raylib
+    just example input
+    just example logo
+    just example font
+    just example model_shader
+    just example raymarch
+    just example rgui
+    just example texture
+    just example yaw_pitch_roll


### PR DESCRIPTION
This makes it so most of the examples run with highdpi so they are
legible on my Fedora machine. It also adds `just examples` that allows
developers to quickly run through and test a sample of examples,
pressing Esc to exit and advance to the next one.
