### PR TITLE
chore: `just examples` runs drop example

### DIFF
--- a/justfile
+++ b/justfile
@@ -57,3 +57,4 @@ examples:
     just example rgui
     just example texture
     just example yaw_pitch_roll
+    just example drop


### PR DESCRIPTION
important example we want to ensure doesn't crash when making changes
