### PR TITLE
chore: rm software renderer examples in justfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,9 +86,9 @@ displays `get_key_name`.
     (`OPENGL_VERSION=Software`). Links and starts, but on Linux/X11 the
     framebuffer-to-window present path is currently broken upstream and windows
     open to a black screen. Track [raylib#4832][rlsw-pr] for progress.
-    `just example-sw <name>` and `just examples-sw` build and run with the
-    feature enabled, useful to smoke-test whether upstream has fixed the
-    presentation path on your platform.
+    No `just` recipe until upstream stabilizes; build with
+    `cargo run --features software_render --bin <name>` inside `examples/`
+    if you want to try it.
   - `platform_memory`: build raylib with the headless `PLATFORM=Memory` backend.
     The feature compiles the backend, but reading the framebuffer requires
     `rlsw.h` APIs (e.g. `swGetColorBuffer`) that are **not yet wrapped** in the

--- a/justfile
+++ b/justfile
@@ -36,11 +36,6 @@ build-examples:
 example name:
     cd examples && cargo run --bin {{ name }}
 
-# Run an example built with raylib's CPU software renderer (rlsw).
-# Defaults to hello_raylib; override with e.g. `just example-sw logo`.
-example-sw name="hello_raylib":
-    cd examples && cargo run --features software_render --bin {{ name }}
-
 # Initializes git submodules
 setup:
     git submodule update --init
@@ -66,8 +61,3 @@ examples:
     just example texture
     just example yaw_pitch_roll
     just example drop
-    just examples-sw
-
-# Smoke-test the CPU software renderer backend (raylib 6.0 `rlsw`).
-examples-sw:
-    just example-sw hello_raylib


### PR DESCRIPTION
aren't working, not a priority yet; I'll add back after 6.0.0 crate release and investigate further

https://github.com/brettchalupa/sola-raylib/issues/29
