### PR TITLE
chore(docs): explain how to use software renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,12 +83,12 @@ displays `get_key_name`.
   as new backends with known gaps. We expose the flags so you can opt in; what
   actually renders or links is whatever upstream supports today.
   - `software_render`: build raylib with the CPU `rlsw` backend
-    (`OPENGL_VERSION=Software`). Links and starts, but on Linux/X11 the
-    framebuffer-to-window present path is currently broken upstream and windows
-    open to a black screen. Track [raylib#4832][rlsw-pr] for progress.
-    `just example-sw <name>` and `just examples-sw` build and run with the
-    feature enabled, useful to smoke-test whether upstream has fixed the
-    presentation path on your platform.
+    (`OPENGL_VERSION=Software`). rlsw is **not compatible with the default GLFW
+    desktop backend** per upstream (raylib#5664), so use it via
+    `--features "sdl,software_render"` on Linux/macOS (requires SDL2 dev
+    headers). `just example-sw <name>` and `just examples-sw` wire that combo
+    for you. Windows would need the `rcore_desktop_win32` native backend, which
+    sola-raylib does not wire yet.
   - `platform_memory`: build raylib with the headless `PLATFORM=Memory` backend.
     The feature compiles the backend, but reading the framebuffer requires
     `rlsw.h` APIs (e.g. `swGetColorBuffer`) that are **not yet wrapped** in the

--- a/README.md
+++ b/README.md
@@ -166,10 +166,24 @@ We surface them for opt-in use, but what actually renders or links is whatever
 raylib's C side supports at HEAD. Expect rough edges.
 
 - `software_render`: compiles raylib with the CPU `rlsw` software rasterizer.
-  Windows open, but the framebuffer-to-window present path is currently broken
-  on at least Linux/X11 upstream (you'll see a black screen even when the
-  renderer reports as `RLSW`). Track
-  [raylib#4832](https://github.com/raysan5/raylib/pull/4832).
+  **Must be combined with the `sdl` feature** on Linux/macOS because rlsw is not
+  compatible with raylib's default GLFW desktop backend (confirmed upstream in
+  [raylib#5664](https://github.com/raysan5/raylib/issues/5664); enabling only
+  `software_render` produces a black window). The `sdl` feature needs SDL dev
+  headers installed at build time; raylib prefers SDL3 and falls back to SDL2,
+  and our `build.rs` auto-detects which is present via `pkg-config`. Install
+  with `sudo dnf install SDL2-devel` on Fedora, `sudo apt install libsdl2-dev`
+  on Debian/Ubuntu, `brew install sdl2` on macOS. Typical usage:
+
+  ```
+  # Linux or macOS, with SDL installed:
+  cargo add sola-raylib --features sdl,software_render
+  ```
+
+  Or to try it from this repo: `just example-sw hello_raylib`.
+
+  Windows would need the `rcore_desktop_win32` native backend (not yet wired in
+  sola-raylib).
 - `platform_memory`: compiles the `PLATFORM=Memory` headless framebuffer
   backend. The backend builds and links; the APIs for reading the framebuffer
   back out (from `rlsw.h`, e.g. `swGetColorBuffer`) are **not yet wrapped in the

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -15,6 +15,7 @@ ringbuf = {version = "0.4.7", optional = true}
 
 [features]
 ringbuf = ["dep:ringbuf"]
+sdl = ["raylib/sdl"]
 software_render = ["raylib/software_render"]
 platform_memory = ["raylib/platform_memory"]
 platform_web_rgfw = ["raylib/platform_web_rgfw"]

--- a/justfile
+++ b/justfile
@@ -36,10 +36,13 @@ build-examples:
 example name:
     cd examples && cargo run --bin {{ name }}
 
-# Run an example built with raylib's CPU software renderer (rlsw).
+# Run an example built with raylib's CPU software renderer (rlsw) over SDL.
+# Requires SDL2 dev headers installed (Fedora: `SDL2-devel`, Debian/Ubuntu:
+# `libsdl2-dev`, macOS/Homebrew: `sdl2`). rlsw is not compatible with GLFW,
+# so we also enable the `sdl` feature; see raylib#5664.
 # Defaults to hello_raylib; override with e.g. `just example-sw logo`.
 example-sw name="hello_raylib":
-    cd examples && cargo run --features software_render --bin {{ name }}
+    cd examples && cargo run --features "sdl,software_render" --bin {{ name }}
 
 # Initializes git submodules
 setup:
@@ -68,6 +71,7 @@ examples:
     just example drop
     just examples-sw
 
-# Smoke-test the CPU software renderer backend (raylib 6.0 `rlsw`).
+# Smoke-test the CPU software renderer backend (raylib 6.0 `rlsw`) over SDL.
+# Requires SDL2 dev headers. See `example-sw` comment above for details.
 examples-sw:
     just example-sw hello_raylib

--- a/raylib-sys/build.rs
+++ b/raylib-sys/build.rs
@@ -166,7 +166,19 @@ fn build_with_cmake(src_path: &str) {
             }
             #[cfg(all(feature = "sdl", not(feature = "platform_memory")))]
             {
-                println!("cargo:rustc-link-lib=SDL2");
+                // raylib's CMake prefers SDL3 via find_package() and falls
+                // back to SDL2 if SDL3 isn't present. Mirror that here so
+                // we link whichever one raylib actually compiled against.
+                let sdl3_present = std::process::Command::new("pkg-config")
+                    .args(["--exists", "sdl3"])
+                    .status()
+                    .map(|s| s.success())
+                    .unwrap_or(false);
+                if sdl3_present {
+                    println!("cargo:rustc-link-lib=SDL3");
+                } else {
+                    println!("cargo:rustc-link-lib=SDL2");
+                }
                 conf.define("PLATFORM", "SDL")
             }
             #[cfg(not(any(feature = "sdl", feature = "platform_memory")))]


### PR DESCRIPTION
It requires SDL2/SDL3, doesn't support GFLW

Ref https://github.com/brettchalupa/sola-raylib/issues/29
