### PR TITLE
chore(release): v6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # sola-raylib Changelog
 
-## 6.0.0 - UNRELEASED
+## 6.0.0 - Apr 24, 2026
 
 Upgrade to **raylib 6.0** and **raygui 5**. sola-raylib's major version tracks
 raylib's, so 6.x binds raylib 6.0. See raylib's [6.0 release notes][raylib-6]

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -44,7 +44,6 @@ Guide to creating new releases on crates.io.
    - `raylib-sys/Cargo.toml` — its own `version`
    - `raylib/Cargo.toml` — its own `version` **and** the `version = "X.Y.Z"`
      pinned on the `raylib-sys` dep line (easy to miss)
-   - `examples/Cargo.toml` — keep in lockstep though not published
    - Any version references in `README.md`
 2. **After the PR merges, tag the merge commit and push the tag:**
    ```

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ changes and the new APIs wrapped from raylib 6.0.
 sola-raylib development happens on `main`. Be sure to view the tag version of
 the repository if you're wanting to find details on a specific version.
 
-The latest released version on crates.io is 5.5.3 (binds raylib 5.5). `main`
-targets raylib 6.0 and compiles cleanly, but 6.0.0 hasn't been tagged yet — pull
-from GitHub if you want it now:
+The latest released version on crates.io is 6.0.0 (binds raylib 6.0).
+
+Pull from GitHub if you want the latest `main`:
 
 ```
 raylib = { package = "sola-raylib", git = "https://github.com/brettchalupa/sola-raylib.git" }
@@ -86,7 +86,7 @@ platform [here](https://github.com/raysan5/raylib/wiki)
 
 ```toml
 [dependencies]
-sola-raylib = "5.5"
+sola-raylib = "6.0"
 ```
 
 Then in your code, use it as `sola_raylib`:
@@ -103,7 +103,7 @@ still imported as `raylib` in your source code:
 
 ```toml
 [dependencies]
-raylib = { package = "sola-raylib", version = "5.5" }
+raylib = { package = "sola-raylib", version = "6.0" }
 ```
 
 With that line, all your existing `raylib` code keeps working. The ./examples in

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -531,7 +531,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sola-raylib"
-version = "6.0.0-dev.0"
+version = "6.0.0"
 dependencies = [
  "cfg-if",
  "paste",
@@ -542,7 +542,7 @@ dependencies = [
 
 [[package]]
 name = "sola-raylib-examples"
-version = "6.0.0-dev.0"
+version = "0.0.0"
 dependencies = [
  "rand",
  "ringbuf",
@@ -552,7 +552,7 @@ dependencies = [
 
 [[package]]
 name = "sola-raylib-sys"
-version = "6.0.0-dev.0"
+version = "6.0.0"
 dependencies = [
  "bindgen",
  "cc",

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "sola-raylib-examples"
-version = "6.0.0-dev.0"
 authors = ["Brett Chalupa <brett@brettchalupa.com>", "raylib-rs team <https://github.com/raylib-rs/raylib-rs>"]
 edition = "2021"
 license = "Zlib"
@@ -8,7 +7,7 @@ readme = "../README.md"
 repository = "https://github.com/brettchalupa/sola-raylib"
 
 [dependencies]
-raylib = { package = "sola-raylib", path = "../raylib", version = "6.0.0-dev.0" }
+raylib = { package = "sola-raylib", path = "../raylib", version = "6.0.0" }
 structopt = "0.3"
 rand = "0.10"
 ringbuf = {version = "0.4.7", optional = true}

--- a/examples/input.rs
+++ b/examples/input.rs
@@ -1,38 +1,160 @@
+//! Input sampler: keyboard, mouse, gamepads. Shows every live signal so you
+//! can verify raylib is seeing what you are doing.
+
 extern crate raylib;
+use raylib::consts::{GamepadButton, MouseButton};
 use raylib::prelude::*;
 use structopt::StructOpt;
 
 mod options;
 
+const GAMEPAD_BUTTONS: &[(GamepadButton, &str)] = &[
+    (GamepadButton::GAMEPAD_BUTTON_LEFT_FACE_UP, "DPad-Up"),
+    (GamepadButton::GAMEPAD_BUTTON_LEFT_FACE_DOWN, "DPad-Down"),
+    (GamepadButton::GAMEPAD_BUTTON_LEFT_FACE_LEFT, "DPad-Left"),
+    (GamepadButton::GAMEPAD_BUTTON_LEFT_FACE_RIGHT, "DPad-Right"),
+    (GamepadButton::GAMEPAD_BUTTON_RIGHT_FACE_UP, "Y/Tri"),
+    (GamepadButton::GAMEPAD_BUTTON_RIGHT_FACE_DOWN, "A/Cross"),
+    (GamepadButton::GAMEPAD_BUTTON_RIGHT_FACE_LEFT, "X/Square"),
+    (GamepadButton::GAMEPAD_BUTTON_RIGHT_FACE_RIGHT, "B/Circle"),
+    (GamepadButton::GAMEPAD_BUTTON_LEFT_TRIGGER_1, "LB"),
+    (GamepadButton::GAMEPAD_BUTTON_LEFT_TRIGGER_2, "LT"),
+    (GamepadButton::GAMEPAD_BUTTON_RIGHT_TRIGGER_1, "RB"),
+    (GamepadButton::GAMEPAD_BUTTON_RIGHT_TRIGGER_2, "RT"),
+    (GamepadButton::GAMEPAD_BUTTON_MIDDLE_LEFT, "Select"),
+    (GamepadButton::GAMEPAD_BUTTON_MIDDLE, "Home"),
+    (GamepadButton::GAMEPAD_BUTTON_MIDDLE_RIGHT, "Start"),
+    (GamepadButton::GAMEPAD_BUTTON_LEFT_THUMB, "L-Stick"),
+    (GamepadButton::GAMEPAD_BUTTON_RIGHT_THUMB, "R-Stick"),
+];
+
+const MOUSE_BUTTONS: &[(MouseButton, &str)] = &[
+    (MouseButton::MOUSE_BUTTON_LEFT, "L"),
+    (MouseButton::MOUSE_BUTTON_MIDDLE, "M"),
+    (MouseButton::MOUSE_BUTTON_RIGHT, "R"),
+    (MouseButton::MOUSE_BUTTON_SIDE, "Side"),
+    (MouseButton::MOUSE_BUTTON_EXTRA, "Extra"),
+    (MouseButton::MOUSE_BUTTON_FORWARD, "Fwd"),
+    (MouseButton::MOUSE_BUTTON_BACK, "Back"),
+];
+
 fn main() {
     let opt = options::Opt::from_args();
     let (mut rl, thread) = opt.open_window("Input");
-    let (_w, _h) = (opt.width, opt.height);
-    let _rust_orange = Color::new(222, 165, 132, 255);
-    let _ray_white = Color::new(255, 255, 255, 255);
 
     rl.set_target_fps(60);
+
     let mut last_key: Option<KeyboardKey> = None;
     let mut last_key_name: Option<String> = None;
+
     while !rl.window_should_close() {
         if let Some(k) = rl.get_key_pressed() {
             last_key_name = rl.get_key_name(k);
             last_key = Some(k);
         }
-        rl.draw(&thread, |mut d| {
-            d.clear_background(Color::WHITE);
-            d.draw_text("Press any key...", 12, 12, 20, Color::DARKGRAY);
-            if let Some(k) = last_key {
-                d.draw_text(&format!("enum: {:?}", k), 12, 48, 20, Color::BLACK);
-                let name = last_key_name.as_deref().unwrap_or("(no layout name)");
-                d.draw_text(
-                    &format!("get_key_name(): {}", name),
-                    12,
-                    80,
-                    20,
-                    Color::DARKBLUE,
-                );
+
+        let mouse = rl.get_mouse_position();
+        let mouse_wheel = rl.get_mouse_wheel_move();
+        let mouse_down: Vec<&str> = MOUSE_BUTTONS
+            .iter()
+            .filter(|(b, _)| rl.is_mouse_button_down(*b))
+            .map(|(_, name)| *name)
+            .collect();
+
+        let mut gamepads: Vec<(i32, Option<String>, Vec<&'static str>)> = Vec::new();
+        for pad in 0..4 {
+            if rl.is_gamepad_available(pad) {
+                let name = rl.get_gamepad_name(pad);
+                let pressed: Vec<&str> = GAMEPAD_BUTTONS
+                    .iter()
+                    .filter(|(b, _)| rl.is_gamepad_button_down(pad, *b))
+                    .map(|(_, label)| *label)
+                    .collect();
+                gamepads.push((pad, name, pressed));
             }
+        }
+
+        rl.draw(&thread, |mut d| {
+            d.clear_background(Color::RAYWHITE);
+
+            let mut y = 12;
+            let section = |d: &mut RaylibDrawHandle, y: &mut i32, title: &str| {
+                d.draw_text(title, 12, *y, 20, Color::DARKBLUE);
+                *y += 28;
+            };
+            let line =
+                |d: &mut RaylibDrawHandle, y: &mut i32, text: &str, color: Color, size: i32| {
+                    d.draw_text(text, 24, *y, size, color);
+                    *y += size + 6;
+                };
+
+            section(&mut d, &mut y, "keyboard");
+            if let Some(k) = last_key {
+                line(
+                    &mut d,
+                    &mut y,
+                    &format!(
+                        "last pressed: {:?} (name: {})",
+                        k,
+                        last_key_name.as_deref().unwrap_or("?")
+                    ),
+                    Color::BLACK,
+                    18,
+                );
+            } else {
+                line(&mut d, &mut y, "press any key...", Color::GRAY, 18);
+            }
+            y += 8;
+
+            section(&mut d, &mut y, "mouse");
+            line(
+                &mut d,
+                &mut y,
+                &format!("pos: ({:.0}, {:.0})  wheel: {:+.1}", mouse.x, mouse.y, mouse_wheel),
+                Color::BLACK,
+                18,
+            );
+            let down = if mouse_down.is_empty() {
+                "(none)".to_owned()
+            } else {
+                mouse_down.join(" ")
+            };
+            line(&mut d, &mut y, &format!("down: {}", down), Color::BLACK, 18);
+            y += 8;
+
+            section(&mut d, &mut y, "gamepads");
+            if gamepads.is_empty() {
+                line(
+                    &mut d,
+                    &mut y,
+                    "no gamepads connected (plug one in)",
+                    Color::GRAY,
+                    18,
+                );
+            } else {
+                for (id, name, pressed) in &gamepads {
+                    line(
+                        &mut d,
+                        &mut y,
+                        &format!(
+                            "#{}: {}",
+                            id,
+                            name.as_deref().unwrap_or("(unnamed)")
+                        ),
+                        Color::BLACK,
+                        18,
+                    );
+                    let pressed_str = if pressed.is_empty() {
+                        "(no buttons down)".to_owned()
+                    } else {
+                        pressed.join(" ")
+                    };
+                    line(&mut d, &mut y, &format!("  {}", pressed_str), Color::DARKGREEN, 18);
+                }
+            }
+
+            // Little mouse crosshair so position feels connected to something.
+            d.draw_circle(mouse.x as i32, mouse.y as i32, 4.0, Color::MAROON);
         });
     }
 }

--- a/raylib-sys/Cargo.toml
+++ b/raylib-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sola-raylib-sys"
-version = "6.0.0-dev.0"
+version = "6.0.0"
 authors = ["Brett Chalupa <brett@brettchalupa.com>", "raylib-rs team <https://github.com/raylib-rs/raylib-rs>"]
 license = "Zlib"
 description = "Raw FFI bindings for raylib. sola-raylib-sys N.x tracks raylib N.x (e.g. 5.x → raylib 5.5; 6.x → raylib 6.0)."

--- a/raylib/Cargo.toml
+++ b/raylib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sola-raylib"
-version = "6.0.0-dev.0"
+version = "6.0.0"
 authors = ["Brett Chalupa <brett@brettchalupa.com>", "raylib-rs team <https://github.com/raylib-rs/raylib-rs>"]
 license = "Zlib"
 readme = "../README.md"
@@ -13,7 +13,7 @@ edition = "2018"
 autoexamples = false
 
 [dependencies]
-raylib-sys = { package = "sola-raylib-sys", version = "6.0.0-dev.0", path = "../raylib-sys" }
+raylib-sys = { package = "sola-raylib-sys", version = "6.0.0", path = "../raylib-sys" }
 cfg-if = "1.0.0"
 serde = { version = "1.0.125", features = ["derive"], optional = true }
 serde_json = { version = "1.0.64", optional = true }


### PR DESCRIPTION
bumps versions; removes ver from examples to not have to deal with that;
expands input example to make it more useful to test and cover gamepads
in particular
