### PR TITLE
fix: custom_frame_control feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@
   `cflag`, so `config.h`'s `#ifndef` guard short-circuits while every other
   default flows through normally. The F12 keybind is gone from the compiled
   `libraylib.a`, rendering and Wayland init are unaffected.
+- **`custom_frame_control` feature was a no-op since the 6.0 bump.** The build
+  used `builder.define("SUPPORT_CUSTOM_FRAME_CONTROL", "ON")`, which sets a
+  CMake variable that only reaches the C compiler when `CUSTOMIZE_BUILD=ON` is
+  also set (and that path is the same one that broke `noscreenshot`). Switched
+  to the same `cflag("-DSUPPORT_CUSTOM_FRAME_CONTROL=1")` approach so the
+  feature actually flips the `#if SUPPORT_CUSTOM_FRAME_CONTROL` guards in
+  `rcore.c` (`SwapScreenBuffer`, `PollInputEvents`, frame-time wait become
+  user-driven, as documented).
 
 [#40]: https://github.com/brettchalupa/sola-raylib/issues/40
 

--- a/raylib-sys/build.rs
+++ b/raylib-sys/build.rs
@@ -81,10 +81,20 @@ fn build_with_cmake(src_path: &str) {
         .define("BUILD_EXAMPLES", "OFF")
         .define("CMAKE_BUILD_TYPE", profile);
 
+    // Enable raylib's `SUPPORT_CUSTOM_FRAME_CONTROL` so the user drives
+    // `SwapScreenBuffer`, `PollInputEvents`, and frame timing manually.
+    //
+    // Same reasoning as `noscreenshot`: pre-define the macro on the C compile
+    // line via `cflag` rather than going through CMake's `CUSTOMIZE_BUILD`
+    // switch. `CUSTOMIZE_BUILD=ON` defines `EXTERNAL_CONFIG_FLAGS`, which
+    // makes raylib's `config.h` skip every other `SUPPORT_*` default and
+    // breaks rendering (issue #40). Pre-defining the single macro lets
+    // `config.h`'s `#ifndef` guard short-circuit while everything else flows
+    // through normally. Before this fix the feature compiled but had no
+    // effect, since `builder.define` only reaches the compiler under
+    // `CUSTOMIZE_BUILD`.
     #[cfg(feature = "custom_frame_control")]
-    {
-        builder.define("SUPPORT_CUSTOM_FRAME_CONTROL", "ON");
-    }
+    builder.cflag("-DSUPPORT_CUSTOM_FRAME_CONTROL=1");
 
     // Enable wayland cmake flag if feature is specified. raylib 6.0 renamed
     // the knob from USE_WAYLAND (gone) to GLFW_BUILD_WAYLAND.


### PR DESCRIPTION
Broke with 6.0.0 and Raylib 6.0, now it's working again.
