### PR TITLE
chore: DRY up version, authors, etc. into workspace root Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,16 @@
 members = ["raylib", "raylib-sys"]
 exclude = ["examples"]
 
+[workspace.package]
+version = "6.1.0"
+authors = ["Brett Chalupa <brett@brettchalupa.com>", "raylib-rs team <https://github.com/raylib-rs/raylib-rs>"]
+license = "Zlib"
+repository = "https://github.com/brettchalupa/sola-raylib"
+edition = "2018"
+
+[workspace.dependencies]
+raylib-sys = { package = "sola-raylib-sys", version = "6.1.0", path = "raylib-sys" }
+
 [workspace.lints.rust]
 # Workspace lints apply only to our own crates, never to dependencies.
 warnings = "deny"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -7,7 +7,7 @@ readme = "../README.md"
 repository = "https://github.com/brettchalupa/sola-raylib"
 
 [dependencies]
-raylib = { package = "sola-raylib", path = "../raylib", version = "6.1.0" }
+raylib = { package = "sola-raylib", path = "../raylib" }
 structopt = "0.3"
 rand = "0.10"
 ringbuf = {version = "0.4.7", optional = true}

--- a/raylib-sys/Cargo.toml
+++ b/raylib-sys/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "sola-raylib-sys"
-version = "6.1.0"
-authors = ["Brett Chalupa <brett@brettchalupa.com>", "raylib-rs team <https://github.com/raylib-rs/raylib-rs>"]
-license = "Zlib"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
 description = "Raw FFI bindings for raylib. sola-raylib-sys N.x tracks raylib N.x (e.g. 5.x → raylib 5.5; 6.x → raylib 6.0)."
 documentation = "https://docs.rs/sola-raylib-sys"
-repository = "https://github.com/brettchalupa/sola-raylib"
 keywords = ["bindings", "raylib", "gamedev", "ffi"]
 categories = ["external-ffi-bindings"]
-edition = "2018"
 exclude = ["raylib/examples/*", "raylib/projects/*", "raylib/templates/*"]
 
 [build-dependencies]

--- a/raylib/Cargo.toml
+++ b/raylib/Cargo.toml
@@ -1,19 +1,19 @@
 [package]
 name = "sola-raylib"
-version = "6.1.0"
-authors = ["Brett Chalupa <brett@brettchalupa.com>", "raylib-rs team <https://github.com/raylib-rs/raylib-rs>"]
-license = "Zlib"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
 readme = "../README.md"
 description = "Safe Rust bindings for raylib. sola-raylib N.x tracks raylib N.x (e.g. 5.x → raylib 5.5; 6.x → raylib 6.0)."
 documentation = "https://docs.rs/sola-raylib"
-repository = "https://github.com/brettchalupa/sola-raylib"
 keywords = ["bindings", "raylib", "gamedev"]
 categories = ["api-bindings", "game-engines", "graphics"]
-edition = "2018"
 autoexamples = false
 
 [dependencies]
-raylib-sys = { package = "sola-raylib-sys", version = "6.1.0", path = "../raylib-sys" }
+raylib-sys = { workspace = true }
 cfg-if = "1.0.0"
 serde = { version = "1.0.125", features = ["derive"], optional = true }
 serde_json = { version = "1.0.64", optional = true }


### PR DESCRIPTION
This will make updating the versions of all the various crates much
easier and reduce potential error for missing one.
