### PR TITLE
feat: RaylibHandle::request_quit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## UNRELEASED
 
+### Added
+
+- **`RaylibHandle::request_quit`.** Programmatic quit for the
+  `sola_raylib::core::game_loop::run` helper (and any hand-rolled
+  `while !rl.window_should_close()` loop). Wire it up to a quit menu item,
+  gamepad button, "game over" transition, etc. `window_should_close` returns
+  true on the next check; on emscripten the registered main loop is cancelled on
+  the next frame. The default ESC / window-close-button paths still work exactly
+  as before. The existing `set_exit_key` API remains the way to change or
+  disable the default exit key.
+
 ## 6.1.0 - May 7, 2026
 
 ### Removed

--- a/examples/hello_raylib.rs
+++ b/examples/hello_raylib.rs
@@ -9,9 +9,17 @@ fn main() {
         .build();
 
     game_loop::run(rl, thread, 60, |rl, thread| {
+        // Programmatic quit. ESC and the OS close button still work as the
+        // raylib defaults; this is how you'd wire a quit menu item, gamepad
+        // button, or any other in-game exit path on native or web.
+        if rl.is_key_pressed(KeyboardKey::KEY_Q) {
+            rl.request_quit();
+        }
+
         let mut d = rl.begin_drawing(thread);
 
         d.clear_background(Color::WHITE);
         d.draw_text("Hello, Raylib", 12, 12, 20, Color::BLACK);
+        d.draw_text("Press Q to quit", 12, 40, 20, Color::DARKGRAY);
     });
 }

--- a/raylib/src/core/game_loop.rs
+++ b/raylib/src/core/game_loop.rs
@@ -34,6 +34,18 @@
 //! The cost is a `'static` closure: no borrowed locals, so `move` your
 //! game state in. On emscripten `run` returns immediately while
 //! emscripten keeps calling the closure each frame.
+//!
+//! ## Quitting
+//!
+//! Native exits when raylib's
+//! [`window_should_close`](crate::core::RaylibHandle::window_should_close)
+//! returns true, which happens on the default exit key (`KEY_ESCAPE`) or the
+//! OS window close button. To trigger that yourself, e.g. from a quit menu
+//! item or gamepad button, call
+//! [`request_quit`](crate::core::RaylibHandle::request_quit) inside the
+//! closure. On emscripten the same call cancels the registered main loop.
+//! Change or disable the default exit key with
+//! [`set_exit_key`](crate::core::RaylibHandle::set_exit_key).
 
 use crate::core::{RaylibHandle, RaylibThread};
 
@@ -48,6 +60,7 @@ extern "C" {
         fps: i32,
         simulate_infinite_loop: i32,
     );
+    fn emscripten_cancel_main_loop();
 }
 
 /// Run `callback` per frame until the window closes (native) or while
@@ -81,6 +94,11 @@ where
             // freed; emscripten calls this forever.
             let state = unsafe { &mut *(arg as *mut State<F>) };
             (state.callback)(&mut state.rl, &state.thread);
+            if crate::core::window::QUIT_REQUESTED
+                .load(std::sync::atomic::Ordering::Relaxed)
+            {
+                unsafe { emscripten_cancel_main_loop() };
+            }
         }
 
         let state = Box::new(State {

--- a/raylib/src/core/game_loop.rs
+++ b/raylib/src/core/game_loop.rs
@@ -94,9 +94,7 @@ where
             // freed; emscripten calls this forever.
             let state = unsafe { &mut *(arg as *mut State<F>) };
             (state.callback)(&mut state.rl, &state.thread);
-            if crate::core::window::QUIT_REQUESTED
-                .load(std::sync::atomic::Ordering::Relaxed)
-            {
+            if crate::core::window::QUIT_REQUESTED.load(std::sync::atomic::Ordering::Relaxed) {
                 unsafe { emscripten_cancel_main_loop() };
             }
         }

--- a/raylib/src/core/window.rs
+++ b/raylib/src/core/window.rs
@@ -4,6 +4,14 @@ use crate::core::{RaylibHandle, RaylibThread};
 use crate::ffi;
 use std::ffi::{CStr, CString, IntoStringError, NulError};
 use std::os::raw::c_char;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+// Process-wide quit flag set by `RaylibHandle::request_quit` and observed by
+// `window_should_close`. raylib only supports one window per process
+// (`init_window` panics on a second `InitWindow`), so a single static is
+// sufficient. Reads/writes are Relaxed because the value is only consulted on
+// the raylib thread.
+pub(crate) static QUIT_REQUESTED: AtomicBool = AtomicBool::new(false);
 
 #[cfg(not(feature = "with_serde"))]
 #[cfg(feature = "serde")]
@@ -511,11 +519,30 @@ impl RaylibHandle {
 
 // Window handling functions
 impl RaylibHandle {
-    /// Checks if `KEY_ESCAPE` or Close icon was pressed.
+    /// Checks if `KEY_ESCAPE` or Close icon was pressed, or if
+    /// [`request_quit`](Self::request_quit) has been called.
     /// Do not call on web unless you are compiling with asyncify.
     #[inline]
     pub fn window_should_close(&self) -> bool {
-        unsafe { ffi::WindowShouldClose() }
+        QUIT_REQUESTED.load(Ordering::Relaxed) || unsafe { ffi::WindowShouldClose() }
+    }
+
+    /// Programmatically signal that the game loop should exit on its next
+    /// iteration, the same as pressing the exit key or clicking the window
+    /// close button.
+    ///
+    /// Use this to wire up a quit menu item, gamepad button, "game over"
+    /// transition, etc., without having to maintain your own boolean flag
+    /// alongside [`window_should_close`](Self::window_should_close). The
+    /// [`game_loop::run`](crate::core::game_loop::run) helper picks this up on
+    /// both native (the `while !window_should_close()` check) and emscripten
+    /// (the loop is cancelled on the next frame).
+    ///
+    /// The flag is process-wide and sticky once set, since raylib only
+    /// supports a single window per process.
+    #[inline]
+    pub fn request_quit(&mut self) {
+        QUIT_REQUESTED.store(true, Ordering::Relaxed);
     }
 
     /// Checks if window has been initialized successfully.


### PR DESCRIPTION
While working on some projects, I noticed there lacked a way to
programmatically quit the game, especially with the new game loop
run helper. This makes it so that `rl.request_quit()` can be
called to do.
