### PR TITLE
fix(sys): auto-configure MSVC environment on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@
   as before. The existing `set_exit_key` API remains the way to change or
   disable the default exit key.
 
+### Fixed
+
+- **Windows MSVC builds now work from a plain shell** ([#56]). When
+  `configure_windows_cmake_generator` picked Ninja (auto-selected when `ninja`
+  is on `PATH`), cmake invoked `cl.exe` directly and failed to find
+  `<windows.h>` unless you'd launched cargo from a Developer Command Prompt or
+  run `vcvars*.bat` first. The build script now uses
+  `cc::windows_registry::find_tool` to locate the MSVC toolchain and injects its
+  `INCLUDE` / `LIB` / `PATH` into the build env. No-op if you're already in a
+  vcvars shell (`INCLUDE` is set) or targeting a non-msvc target. Thanks to
+  @lofcz.
+
+[#56]: https://github.com/brettchalupa/sola-raylib/pull/56
+
 ## 6.1.0 - May 7, 2026
 
 ### Removed

--- a/raylib-sys/build.rs
+++ b/raylib-sys/build.rs
@@ -433,6 +433,35 @@ fn configure_windows_cmake_generator() {
     }
 }
 
+/// Inject the MSVC env vars into the build environment for Windows builds.
+fn configure_windows_msvc_env(target: &str) {
+    if !cfg!(windows) || target.contains("wasm") || !target.contains("msvc") {
+        return;
+    }
+
+    if env::var_os("INCLUDE").is_some() {
+        return;
+    }
+
+    let Some(tool) = cc::windows_registry::find_tool(target, "cl.exe") else {
+        println!("cargo:warning=could not locate the MSVC toolchain; set up vcvars manually if the build fails");
+        return;
+    };
+
+    for (key, value) in tool.env() {
+        if key.to_string_lossy().eq_ignore_ascii_case("path") {
+            let mut combined = value.clone();
+            if let Some(existing) = env::var_os("PATH") {
+                combined.push(";");
+                combined.push(existing);
+            }
+            env::set_var("PATH", combined);
+        } else {
+            env::set_var(key, value);
+        }
+    }
+}
+
 fn command_exists(name: &str) -> bool {
     env::var_os("PATH")
         .and_then(|paths| {
@@ -576,6 +605,8 @@ fn main() {
     emit_env_change_triggers();
     let target = env::var("TARGET").expect("Cargo build scripts always have TARGET");
 
+    configure_windows_msvc_env(&target);
+
     let (platform, platform_os) = platform_from_target(&target);
 
     let raylib_src = "./raylib";
@@ -597,6 +628,8 @@ fn main() {
     println!("cargo:rerun-if-changed=./binding/binding.h");
     emit_env_change_triggers();
     let target = env::var("TARGET").expect("Cargo build scripts always have TARGET");
+
+    configure_windows_msvc_env(&target);
 
     if target.contains("wasm32-unknown-emscripten") {
         if let Err(e) = env::var("EMCC_CFLAGS") {


### PR DESCRIPTION
  On Windows, building could be simplified by leveraging `cc` in `build.rs` to locate the MSVC toolchain and inject its env vars into the build environment. Mirrors existing `configure_windows_cmake_generator` env handling.

PS: thanks for your work, been searching for rust bindings to try the new software renderer and found this gem. Definitely deserves more stars.