### PR TITLE
feat!: shader and image anim loading return results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 ## UNRELEASED
 
+### BREAKING
+
+- **`RaylibHandle::load_shader` and `load_shader_from_memory` are now fallible**
+  ([#51]). Both return `Result<Shader, Error>` instead of `Shader`. raylib
+  silently logs a warning and substitutes the default shader when a file is
+  missing or a shader fails to compile, so the old signatures made those
+  failures look like success. `load_shader` now also checks each provided path
+  exists before calling raylib, necessary because a missing file comes back as
+  the (valid, non-zero) default shader id and is otherwise undetectable. This is
+  a breaking signature change, but a loud, compile-time one: add `?` or
+  `.unwrap()` at the call site.
+
+  ```rust
+  // before
+  let shader = rl.load_shader(&thread, None, Some("grayscale.fs"));
+  // after
+  let shader = rl.load_shader(&thread, None, Some("grayscale.fs"))?;
+  ```
+
+  Caveat: a vertex/fragment pair that compiles individually but fails to _link_
+  still slips through, since raylib reassigns the default shader id internally
+  and the failure can't be observed from the binding.
+
+- **`Image::load_image_anim` and `load_image_anim_from_memory` are now
+  fallible** ([#51]). Both return `Result<Image, Error>` instead of `Image`,
+  checking for the null `data` raylib hands back on failure. This brings them in
+  line with their non-animated siblings (`load_image`, `load_image_raw`,
+  `load_image_from_mem`), which already returned `Result`. Add `?` or
+  `.unwrap()` at the call site.
+
+[#51]: https://github.com/brettchalupa/sola-raylib/issues/51
+
 ### Added
 
 - **`RaylibHandle::request_quit`.** Programmatic quit for the

--- a/examples/model_shader.rs
+++ b/examples/model_shader.rs
@@ -18,7 +18,9 @@ fn main() {
     rl.set_target_fps(60);
 
     // Load shader
-    let shader = rl.load_shader(&thread, None, Some("static/model_shader/grayscale.fs"));
+    let shader = rl
+        .load_shader(&thread, None, Some("static/model_shader/grayscale.fs"))
+        .unwrap();
 
     // Load model
     let mut model = rl

--- a/examples/raymarch.rs
+++ b/examples/raymarch.rs
@@ -18,7 +18,9 @@ pub fn main() {
         65.0,
     );
 
-    let mut shader = rl.load_shader_from_memory(&thread, None, Some(SHADER));
+    let mut shader = rl
+        .load_shader_from_memory(&thread, None, Some(SHADER))
+        .unwrap();
     // let s = std::fs::read_to_string("raymarch-static/raymarching.fs").expect("couldn't read");
     // println!("{}", s);
 

--- a/examples/shader_multisample.rs
+++ b/examples/shader_multisample.rs
@@ -7,7 +7,9 @@ pub fn main() {
     let im_blue = Image::gen_image_color(800, 450, Color::new(0, 0, 255, 255));
     let tex_blue = rl.load_texture_from_image(&thread, &im_blue).unwrap();
 
-    let mut shader = rl.load_shader(&thread, None, Some("static/shader/color_mix.fs"));
+    let mut shader = rl
+        .load_shader(&thread, None, Some("static/shader/color_mix.fs"))
+        .unwrap();
 
     // Get an additional sampler2D location to be enabled on drawing
     let tex_blue_loc = shader.get_shader_location("texture1");

--- a/raylib/src/core/shaders.rs
+++ b/raylib/src/core/shaders.rs
@@ -4,46 +4,88 @@ use crate::consts::ShaderUniformDataType;
 use crate::core::math::Matrix;
 use crate::core::math::{Vector2, Vector3, Vector4};
 use crate::core::{RaylibHandle, RaylibThread};
+use crate::error::{error, Error};
 use crate::ffi;
 use std::ffi::CString;
 use std::os::raw::{c_char, c_void};
+use std::path::Path;
 
 fn no_drop<T>(_thing: T) {}
 make_thin_wrapper!(Shader, ffi::Shader, ffi::UnloadShader);
 make_thin_wrapper!(WeakShader, ffi::Shader, no_drop);
 
 impl RaylibHandle {
-    /// Loads a custom shader and binds default locations.
+    /// Loads a custom shader from files and binds default locations.
+    ///
+    /// Pass `None` for either stage to use raylib's built-in default vertex or
+    /// fragment shader. Passing `None` for both returns the default shader.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`Error`] when a provided file path does not exist, or when a
+    /// shader is found but fails to compile. raylib itself only logs a warning
+    /// and silently substitutes the default shader in these cases; this wrapper
+    /// surfaces them so the fallback is opt-in rather than the default.
+    ///
+    /// Note: if both a vertex *and* fragment file are provided and the two
+    /// compile individually but fail to *link* together, raylib reassigns the
+    /// default shader id internally and the failure cannot be detected here.
     pub fn load_shader(
         &mut self,
         _: &RaylibThread,
         vs_filename: Option<&str>,
         fs_filename: Option<&str>,
-    ) -> Shader {
+    ) -> Result<Shader, Error> {
+        // A missing file is the case the binding most needs to catch, but
+        // raylib falls back to the (valid, non-zero) default shader id when a
+        // file can't be read, so the returned shader looks fine. Check the
+        // paths up front to turn that into a real error.
+        for filename in vs_filename.iter().chain(fs_filename.iter()) {
+            if !Path::new(filename).exists() {
+                return Err(error!("shader file does not exist", filename));
+            }
+        }
+
         let c_vs_filename = vs_filename.map(|f| CString::new(f).unwrap());
         let c_fs_filename = fs_filename.map(|f| CString::new(f).unwrap());
 
         // Trust me, I have tried ALL the RUST option ergonamics. This is the only way
         // to get this to work without raylib breaking for whatever reason
         // UPDATE FOR 2024 FROM ANOTHER PERSON: Yes this is still true, doing although "for some reason" is likely due to the pointer getting freed too early if you don't do it this way.
-        match (c_vs_filename, c_fs_filename) {
+        let shader = match (c_vs_filename, c_fs_filename) {
             (Some(vs), Some(fs)) => unsafe { Shader(ffi::LoadShader(vs.as_ptr(), fs.as_ptr())) },
             (None, Some(fs)) => unsafe { Shader(ffi::LoadShader(std::ptr::null(), fs.as_ptr())) },
             (Some(vs), None) => unsafe { Shader(ffi::LoadShader(vs.as_ptr(), std::ptr::null())) },
             (None, None) => unsafe { Shader(ffi::LoadShader(std::ptr::null(), std::ptr::null())) },
+        };
+
+        if !shader.is_shader_valid() {
+            return Err(error!("shader failed to compile"));
         }
+        Ok(shader)
     }
 
-    /// Loads shader from code strings and binds default locations.
+    /// Loads a shader from code strings and binds default locations.
+    ///
+    /// Pass `None` for either stage to use raylib's built-in default vertex or
+    /// fragment shader. Passing `None` for both returns the default shader.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`Error`] when the provided shader code fails to compile.
+    /// raylib itself only logs a warning and silently substitutes the default
+    /// shader; this wrapper surfaces the failure instead. As with
+    /// [`load_shader`](Self::load_shader), a vertex/fragment pair that compiles
+    /// individually but fails to link cannot be detected here.
     pub fn load_shader_from_memory(
         &mut self,
         _: &RaylibThread,
         vs_code: Option<&str>,
         fs_code: Option<&str>,
-    ) -> Shader {
+    ) -> Result<Shader, Error> {
         let c_vs_code = vs_code.map(|f| CString::new(f).unwrap());
         let c_fs_code = fs_code.map(|f| CString::new(f).unwrap());
-        match (c_vs_code, c_fs_code) {
+        let shader = match (c_vs_code, c_fs_code) {
             (Some(vs), Some(fs)) => unsafe {
                 Shader(ffi::LoadShaderFromMemory(
                     vs.as_ptr() as *mut c_char,
@@ -68,7 +110,12 @@ impl RaylibHandle {
                     std::ptr::null_mut(),
                 ))
             },
+        };
+
+        if !shader.is_shader_valid() {
+            return Err(error!("shader failed to compile from memory"));
         }
+        Ok(shader)
     }
 
     /// Get default shader. Modifying it modifies everthing that uses that shader

--- a/raylib/src/core/texture.rs
+++ b/raylib/src/core/texture.rs
@@ -967,25 +967,53 @@ impl Image {
     /// Image.data buffer includes all frames.
     /// All frames returned are in RGBA format.
     /// Frames delay data is discarded
-    pub fn load_image_anim(filename: &str, frame_num: &mut i32) -> Self {
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`Error`] when the file can't be loaded (raylib returns an
+    /// image with null data, which this surfaces instead of silently passing
+    /// along an empty image).
+    pub fn load_image_anim(filename: &str, frame_num: &mut i32) -> Result<Image, Error> {
         let c_filename = CString::new(filename).unwrap();
 
-        unsafe { Image(ffi::LoadImageAnim(c_filename.as_ptr(), frame_num)) }
+        let i = unsafe { ffi::LoadImageAnim(c_filename.as_ptr(), frame_num) };
+        if i.data.is_null() {
+            return Err(error!(
+                "Image data is null. Check if the file exists and is a supported format.",
+                filename
+            ));
+        }
+        Ok(Image(i))
     }
 
     /// Load image from memory buffer, with the number of frames loaded saved to frame_num.
     /// fileType refers to extension: i.e. ".png". File extension must be provided in lower-case
-    pub fn load_image_anim_from_memory(filetype: &str, data: &[u8], frame_num: &mut i32) -> Self {
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`Error`] when the buffer can't be decoded (raylib returns an
+    /// image with null data).
+    pub fn load_image_anim_from_memory(
+        filetype: &str,
+        data: &[u8],
+        frame_num: &mut i32,
+    ) -> Result<Image, Error> {
         let c_filetype = CString::new(filetype).unwrap();
 
-        unsafe {
-            Image(ffi::LoadImageAnimFromMemory(
+        let i = unsafe {
+            ffi::LoadImageAnimFromMemory(
                 c_filetype.as_ptr(),
                 data.as_ptr(),
                 data.len() as i32,
                 frame_num,
-            ))
+            )
+        };
+        if i.data.is_null() {
+            return Err(error!(
+                "Image data is null. Check provided buffer data and file type."
+            ));
         }
+        Ok(Image(i))
     }
 
     /// Loads image from RAW file data.


### PR DESCRIPTION
BREAKING:  `load_shader`, `load_shader_from_memory`, `load_image_anim`,
and `load_image_anim_from_memory` return a Result, append `?` or
`unwrap()` or handle the Result explicitly.

This makes it so that `load_shader`, `load_shader_from_memory`,
`load_image_anim`, and `load_image_anim_from_memory` return a result
rather than failing silently. This matches the other loaders in the
crate and is more Rust-y.

Closes https://github.com/brettchalupa/sola-raylib/issues/51
