### PR TITLE
fix(input): only show joysticks with valid gamepad mappings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 No unreleased changes.
 
+### Fixes
+
+- Don't show non-gamepad joysticks on Linux as gamepads. Previous versions were
+  showing some keyboards, some mainboard sensors, etc. as gamepads which was
+  wrong and confusing. While the issue is upstream in Raylib and GLFW, there's
+  seemingly little appetite or momentum in fixing this, so sola-raylb now
+  applies a check for gamepad mapping. This means that controllers without a
+  mapping won't show up as detected, but that's better than showing up and not
+  working. See https://github.com/brettchalupa/sola-raylib/issues/62
+
 ## 6.2.0 - June 2, 2026
 
 ### BREAKING

--- a/raylib/src/core/input.rs
+++ b/raylib/src/core/input.rs
@@ -9,6 +9,18 @@ use crate::ffi;
 use std::ffi::c_char;
 use std::ffi::CStr;
 
+// GLFW is statically linked into the raylib library on the desktop and web
+// backends, so we can call its joystick API directly. raylib only exposes
+// `IsGamepadAvailable`, which reports any present joystick, but GLFW registers
+// every input device with an absolute axis (mainboard sensors, some keyboards)
+// as a joystick. `glfwJoystickIsGamepad` is true only for devices with a valid
+// gamepad mapping, which is exactly the set raylib's GLFW input path can read.
+// Not declared on the SDL backend, where GLFW is absent and SDL already filters.
+#[cfg(not(feature = "sdl"))]
+extern "C" {
+    fn glfwJoystickIsGamepad(jid: std::ffi::c_int) -> std::ffi::c_int;
+}
+
 impl RaylibHandle {
     /// Detect if a key has been pressed once.
     #[inline]
@@ -95,9 +107,27 @@ impl RaylibHandle {
     }
 
     /// Detect if a gamepad is available.
+    ///
+    /// On the GLFW backend this additionally requires the device to have a
+    /// valid gamepad mapping (`glfwJoystickIsGamepad`), so non-controller
+    /// devices that GLFW registers as joysticks (mainboard sensors, some
+    /// keyboards) are not reported. This matches the SDL backend, which only
+    /// surfaces mapped controllers.
     #[inline]
     pub fn is_gamepad_available(&self, gamepad: i32) -> bool {
-        unsafe { ffi::IsGamepadAvailable(gamepad) }
+        unsafe {
+            if !ffi::IsGamepadAvailable(gamepad) {
+                return false;
+            }
+            #[cfg(not(feature = "sdl"))]
+            {
+                glfwJoystickIsGamepad(gamepad) != 0
+            }
+            #[cfg(feature = "sdl")]
+            {
+                true
+            }
+        }
     }
 
     /// Returns gamepad internal name id.


### PR DESCRIPTION
Keyboards, mainboard controllers, etc. show up as joysticks on linux
even though they're not valid gamepads. This is confusing to developers
and IMO should be filtered out. Upstream Raylib C basically said this is
a GLFW upstream issue, but I don't want to just kick the can down the road
and want a solution. So this seems reasonable to filter them out.

One downside of this is that some joysticks that are in reality gamepads
but lack a mapping won't appear any longer. But I think that's better
than them not working at all... otherwise it's super confusing. Fix for
that is https://github.com/brettchalupa/sola-raylib/issues/63 - keep a
more updated controller db in the library.

Ref https://codeberg.org/brettchalupa/usagi/issues/4
Fixes https://github.com/brettchalupa/sola-raylib/issues/62
