### PR TITLE
fix: OOB read when loading/unloading fonts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
   applies a check for gamepad mapping. This means that controllers without a
   mapping won't show up as detected, but that's better than showing up and not
   working. See https://github.com/brettchalupa/sola-raylib/issues/62
+- Fix segfault due to OOB read when using certain characters; see
+  https://github.com/brettchalupa/sola-raylib/pull/67
 
 ## 6.2.0 - June 2, 2026
 

--- a/raylib/src/core/text.rs
+++ b/raylib/src/core/text.rs
@@ -139,7 +139,7 @@ impl RaylibHandle {
                         c_filename.as_ptr(),
                         font_size,
                         co.0.as_mut_ptr(),
-                        c.len() as i32,
+                        co.0.len() as i32,
                     )
                 }
                 None => ffi::LoadFontEx(c_filename.as_ptr(), font_size, std::ptr::null_mut(), 0),
@@ -192,7 +192,7 @@ impl RaylibHandle {
                         file_data.len() as i32,
                         font_size,
                         co.0.as_mut_ptr(),
-                        c.chars().count() as i32,
+                        co.0.len() as i32,
                     )
                 }
                 None => ffi::LoadFontFromMemory(
@@ -235,7 +235,7 @@ impl RaylibHandle {
                         data.len() as i32,
                         font_size,
                         co.0.as_mut_ptr(),
-                        c.len() as i32,
+                        co.0.len() as i32,
                         sdf,
                         &mut glyph_count,
                     )
@@ -445,5 +445,54 @@ impl RaylibHandle {
 
     pub fn set_text_line_spacing(&self, spacing: i32) {
         unsafe { ffi::SetTextLineSpacing(spacing) }
+    }
+}
+
+#[cfg(test)]
+mod codepoint_tests {
+    use crate::ffi;
+    use std::ffi::CString;
+
+    /// Reconstructs the codepoint array exactly like `load_codepoints` does,
+    /// returning `(byte_len, codepoints)` so tests can compare the two.
+    ///
+    /// SAFETY: `LoadCodepoints`/`UnloadCodepoints` are pure text-parsing
+    /// helpers in raylib's rtext module and need no window or GPU context.
+    fn codepoints(text: &str) -> (usize, Vec<i32>) {
+        let ptr = CString::new(text).unwrap();
+        let mut len = 0;
+        unsafe {
+            let u = ffi::LoadCodepoints(ptr.as_ptr(), &mut len);
+            let slice = std::slice::from_raw_parts(u, len as usize);
+            let out = slice.to_vec();
+            ffi::UnloadCodepoints(u);
+            (text.len(), out)
+        }
+    }
+
+    /// Regression test for the OOB read fix
+    #[test]
+    fn codepoint_count_differs_from_byte_len_for_multibyte() {
+        // '¿' is 2 bytes, 1 codepoint.
+        let (byte_len, cps) = codepoints("¿");
+        assert_eq!(byte_len, 2, "'¿' is two UTF-8 bytes");
+        assert_eq!(cps.len(), 1, "'¿' is a single codepoint");
+        assert_eq!(cps[0], 0xBF, "codepoint of '¿' is U+00BF");
+    }
+
+    #[test]
+    fn codepoint_count_matches_char_count_for_mixed_string() {
+        let text = "a¿b€c"; // ascii + 2-byte + 3-byte, 5 chars, 8 bytes
+        let (byte_len, cps) = codepoints(text);
+        assert_eq!(byte_len, 8);
+        assert_eq!(cps.len(), text.chars().count());
+        assert_eq!(cps.len(), 5);
+    }
+
+    #[test]
+    fn ascii_count_equals_byte_len() {
+        let (byte_len, cps) = codepoints("hello");
+        assert_eq!(byte_len, 5);
+        assert_eq!(cps.len(), 5);
     }
 }

--- a/raylib/src/core/text.rs
+++ b/raylib/src/core/text.rs
@@ -92,7 +92,7 @@ impl RaylibHandle {
 
         unsafe {
             Codepoints(std::mem::ManuallyDrop::new(Box::from_raw(
-                std::ptr::slice_from_raw_parts_mut(u, text.len()),
+                std::ptr::slice_from_raw_parts_mut(u, len as usize),
             )))
         }
     }
@@ -192,7 +192,7 @@ impl RaylibHandle {
                         file_data.len() as i32,
                         font_size,
                         co.0.as_mut_ptr(),
-                        c.len() as i32,
+                        c.chars().count() as i32,
                     )
                 }
                 None => ffi::LoadFontFromMemory(


### PR DESCRIPTION
Hi, I hope you're having a good day.
I was encontering a segfault in my project under certain conditions so I went to investigate it.
In my projects, I'm using chars like '¿', which have more than 1 byte size, so it was triggering an OOB read.
(ex. try to load "¿", it'd show you a warning that only 1/2 characters loaded correctly (the one that didn't load correctly is garbage, and may sometimes crash the code.)

Cheers!