### PR TITLE
fix(window): don't panic for mmonitor index range asserts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
   working. See https://github.com/brettchalupa/sola-raylib/issues/62
 - Fix segfault due to OOB read when using certain characters; see
   https://github.com/brettchalupa/sola-raylib/pull/67
+- Fix window monitor functions panicing with SDL backend; see
+  https://github.com/brettchalupa/sola-raylib/issues/65
 
 ## 6.2.0 - June 2, 2026
 

--- a/raylib/src/core/window.rs
+++ b/raylib/src/core/window.rs
@@ -274,61 +274,36 @@ pub fn get_current_monitor_index() -> i32 {
 /// Get specified monitor refresh rate
 #[inline]
 pub fn get_monitor_refresh_rate(monitor: i32) -> i32 {
-    debug_assert!(
-        monitor < get_monitor_count() && monitor >= 0,
-        "monitor index out of range"
-    );
-
     unsafe { ffi::GetMonitorRefreshRate(monitor) }
 }
 
 /// Get width of monitor
-/// Only checks that monitor index is in range in debug mode
 #[inline]
 pub fn get_monitor_width(monitor: i32) -> i32 {
-    let len = get_monitor_count();
-    debug_assert!(monitor < len && monitor >= 0, "monitor index out of range");
-
     unsafe { ffi::GetMonitorWidth(monitor) }
 }
 
 /// Get height of monitor
-/// Only checks that monitor index is in range in debug mode
 #[inline]
 pub fn get_monitor_height(monitor: i32) -> i32 {
-    let len = get_monitor_count();
-    debug_assert!(monitor < len && monitor >= 0, "monitor index out of range");
-
     unsafe { ffi::GetMonitorHeight(monitor) }
 }
 
 /// Get physical width of monitor
-/// Only checks that monitor index is in range in debug mode
 #[inline]
 pub fn get_monitor_physical_width(monitor: i32) -> i32 {
-    let len = get_monitor_count();
-    debug_assert!(monitor < len && monitor >= 0, "monitor index out of range");
-
     unsafe { ffi::GetMonitorPhysicalWidth(monitor) }
 }
 
 /// Get physical height of monitor
-/// Only checks that monitor index is in range in debug mode
 #[inline]
 pub fn get_monitor_physical_height(monitor: i32) -> i32 {
-    let len = get_monitor_count();
-    debug_assert!(monitor < len && monitor >= 0, "monitor index out of range");
-
     unsafe { ffi::GetMonitorPhysicalHeight(monitor) }
 }
 
 /// Get name of monitor
-/// Only checks that monitor index is in range in debug mode
 #[inline]
 pub fn get_monitor_name(monitor: i32) -> Result<String, IntoStringError> {
-    let len = get_monitor_count();
-    debug_assert!(monitor < len && monitor >= 0, "monitor index out of range");
-
     Ok(unsafe {
         let c = CString::from_raw(ffi::GetMonitorName(monitor) as *mut c_char);
         c.into_string()?
@@ -336,12 +311,8 @@ pub fn get_monitor_name(monitor: i32) -> Result<String, IntoStringError> {
 }
 
 /// Get position of monitor
-/// Only checks that monitor index is in range in debug mode
 #[inline]
 pub fn get_monitor_position(monitor: i32) -> Vector2 {
-    let len = get_monitor_count();
-    debug_assert!(monitor < len && monitor >= 0, "monitor index out of range");
-
     unsafe { ffi::GetMonitorPosition(monitor).into() }
 }
 
@@ -359,9 +330,6 @@ pub fn get_monitor_position(monitor: i32) -> Vector2 {
 /// }
 /// ```
 pub fn get_monitor_info(monitor: i32) -> Result<MonitorInfo, IntoStringError> {
-    let len = get_monitor_count();
-    debug_assert!(monitor < len && monitor >= 0, "monitor index out of range");
-
     Ok(MonitorInfo {
         width: get_monitor_width(monitor),
         height: get_monitor_height(monitor),
@@ -726,8 +694,6 @@ impl RaylibHandle {
     /// Sets monitor for the current window (fullscreen mode).
     #[inline]
     pub fn set_window_monitor(&mut self, monitor: i32) {
-        let len = get_monitor_count();
-        debug_assert!(monitor < len && monitor >= 0, "monitor index out of range");
         unsafe {
             ffi::SetWindowMonitor(monitor);
         }


### PR DESCRIPTION
The `get_monitor_*` wrappers (and `set_window_monitor`) each ran a
`debug_assert!(monitor < get_monitor_count() && monitor >= 0)` before
calling into the ffi. That check assumes `monitor` is a 0-based index in
`0..count`, which is not true on the SDL backend.

Under SDL3, `GetCurrentMonitor()` returns a display **ID**, not an
index (see the note in raylib's `rcore_desktop_sdl.c`). SDL3 display IDs
are 1-based, so the current monitor's ID is essentially always `>=
get_monitor_count()`. Even the common single-monitor case fails:
count is 1, the current ID is 1, and `1 < 1` is false. Feeding
`get_current_monitor()` into any of these functions then panics in
debug builds (`debug_assertions` is on by default for `cargo run`).

The assert added no safety: the raylib C functions already validate
their argument (SDL3 checks the ID with `SDL_GetDisplayProperties`,
other backends range-check the index) and return 0 with a warning on
bad input. The wrapper's extra check just encoded a backend-specific
index assumption and turned valid IDs into spurious panics.

Removes the range asserts so all backends behave like the underlying
ffi. Non-SDL backends are unaffected (they already passed the check);
SDL builds no longer panic on valid monitor IDs.

Fixes https://github.com/brettchalupa/sola-raylib/issues/65
